### PR TITLE
Fixes to URL

### DIFF
--- a/actions/image2disk/v1/README.md
+++ b/actions/image2disk/v1/README.md
@@ -20,7 +20,7 @@ actions:
       image: quay.io/tinkerbell-actions/image2disk:v1.0.0
       timeout: 90
       environment:
-          IMG_URL: 192.168.1.2/ubuntu.raw
+          IMG_URL: http://192.168.1.2/ubuntu.raw
           DEST_DISK: /dev/sda
           COMPRESSED: false
 ```
@@ -39,7 +39,7 @@ actions:
       image: quay.io/tinkerbell-actions/image2disk:v1.0.0
       timeout: 90
       environment:
-          IMG_URL: 192.168.1.2/ubuntu.tar.gz
+          IMG_URL: http://192.168.1.2/ubuntu.tar.gz
           DEST_DISK: /dev/sda
           COMPRESSED: true
 ```


### PR DESCRIPTION
The `http://` needs adding to the URL otherwise it wont be parsed correctly.

## Description

Fixes documentation to ensure action is used correctly.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
