### PR TITLE
chore(mergify): enable support for main branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-      - base=master
+      - base=main
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
The default configuration we have for mergify rely on base branch to
be master. But hub uses main.
