### PR TITLE
This adds Syslinux installation support as an action

### DIFF
--- a/actions/syslinux/v1/Dockerfile
+++ b/actions/syslinux/v1/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:experimental
+
+# Build syslinux as an syslinux3.86
+FROM gcc:10.2.0 as syslinux3.86
+RUN apt-get update -y; apt-get install -y nasm build-essential uuid-dev
+RUN wget https://cdn.kernel.org/pub/linux/utils/boot/syslinux/3.xx/syslinux-3.86.tar.gz; tar -xvzf ./syslinux-3.86.tar.gz
+WORKDIR /syslinux-3.86/libinstaller
+RUN make
+WORKDIR /syslinux-3.86/linux
+RUN gcc -Wp,-MT,syslinux.o,-MMD,./.syslinux.o.d -W -Wall -Wstrict-prototypes -D_FILE_OFFSET_BITS=64 -g -Os -I. -I.. -I../libinstaller -static -c -o syslinux.o syslinux.c
+RUN gcc -Wp,-MT,syslxmod.o,-MMD,./.syslxmod.o.d -W -Wall -Wstrict-prototypes -D_FILE_OFFSET_BITS=64 -g -Os -I. -I.. -I../libinstaller -static -c -o syslxmod.o ../libinstaller/syslxmod.c
+RUN gcc -Wp,-MT,bootsect_bin.o,-MMD,./.bootsect_bin.o.d -W -Wall -Wstrict-prototypes -D_FILE_OFFSET_BITS=64 -g -Os -I. -I.. -I../libinstaller -static -c -o bootsect_bin.o ../libinstaller/bootsect_bin.c
+RUN gcc -Wp,-MT,ldlinux_bin.o,-MMD,./.ldlinux_bin.o.d -W -Wall -Wstrict-prototypes -D_FILE_OFFSET_BITS=64 -g -Os -I. -I.. -I../libinstaller -static -c -o ldlinux_bin.o ../libinstaller/ldlinux_bin.c
+RUN gcc -s -static -o syslinux syslinux.o syslxmod.o bootsect_bin.o ldlinux_bin.o
+
+# Build syslinux
+FROM golang:1.15-alpine as syslinux
+RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
+COPY . /go/src/github.com/thebsdbox/syslinux/
+WORKDIR /go/src/github.com/thebsdbox/syslinux
+ENV GO111MODULE=on
+RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
+    --mount=type=cache,sharing=locked,id=goroot,target=/root/.cache/go-build \
+    CGO_ENABLED=1 GOOS=linux go build -a -ldflags "-linkmode external -extldflags '-static' -s -w" -o syslinux
+
+# Build final image
+FROM alpine
+COPY --from=syslinux3.86 /syslinux-3.86/mbr/mbr.bin /mbr.bin.386
+COPY --from=syslinux3.86 /syslinux-3.86/linux/syslinux /syslinux.386
+COPY --from=syslinux /go/src/github.com/thebsdbox/syslinux/syslinux .
+ENTRYPOINT ["/syslinux"]

--- a/actions/syslinux/v1/Makefile
+++ b/actions/syslinux/v1/Makefile
@@ -1,0 +1,5 @@
+image:
+	docker buildx build  --platform linux/amd64 --push -t thebsdbox/syslinux:1.0.0 .
+
+image-local:
+	docker buildx build  --platform linux/amd64 --load -t thebsdbox/syslinux:1.0.0 .

--- a/actions/syslinux/v1/README.md
+++ b/actions/syslinux/v1/README.md
@@ -1,0 +1,28 @@
+---
+slug: syslinux
+name: syslinux
+tags: disk, boot loader
+maintainers: Dan Finneran <daniel.finneran@gmail.com>
+description: "This action can be used to install syslinux as a boot loader, in two parts
+it will install the MBR at `DEST_DISK` and install the boot loader on the specified 
+partition at `DEST_PARTITION`. Currently the only version of syslinux available is
+`3.86`."
+version: v1.0.0
+createdAt: "2021-03-01T12:41:45.14Z"
+---
+
+The below example will use the install the [syslinux](https://wiki.archlinux.org/index.php/syslinux) boot loader to a
+specified block device. The installation consists of installing an MBE to the
+first few sectors of the disk, then installing the boot loader on the FAT32
+filesystem (on the specified partition).
+
+```yaml
+actions:
+    - name: "install syslinux to /dev/sda"
+      image: quay.io/tinkerbell-actions/syslinux:v1.0.0
+      timeout: 90
+      environment:
+          DEST_DISK: /dev/sdb
+          DEST_PARTITION: /dev/sdb1
+          SYSLINUX_VERSION: 3.86
+```

--- a/actions/syslinux/v1/go.mod
+++ b/actions/syslinux/v1/go.mod
@@ -1,0 +1,9 @@
+module github.com/tinkerbell/hub/actions/syslinux/v1
+
+go 1.15
+
+require (
+	github.com/sirupsen/logrus v1.7.0
+	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f
+)

--- a/actions/syslinux/v1/go.sum
+++ b/actions/syslinux/v1/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
+golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/actions/syslinux/v1/main.go
+++ b/actions/syslinux/v1/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+
+	fmt.Printf("SYSLINUX - Boot Loader Installation\n------------------------\n")
+	disk := os.Getenv("DEST_DISK")
+	partition := os.Getenv("DEST_PARTITION")
+
+	ver := os.Getenv("SYSLINUX_VERSION")
+
+	switch ver {
+	case "386", "3.86":
+		syslinux386(disk, partition)
+	default:
+		log.Fatalf("Unknown syslinux version [%s]", ver)
+	}
+
+}
+
+func syslinux386(disk, partition string) {
+	log.Infof("Writing mbr to [%s] and installing boot loader to [%s]", disk, partition)
+	// Open the block device and write the Master boot record
+	blockOut, err := os.OpenFile(disk, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	ReReadPartitionTable(blockOut)
+	defer blockOut.Close()
+
+	mbrIn, err := os.OpenFile("/mbr.bin.386", os.O_RDONLY, 0644)
+	defer mbrIn.Close()
+
+	_, err = io.Copy(blockOut, mbrIn)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	_, err = os.Stat(partition)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	cmd := exec.Command("/syslinux.386", partition)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	err = cmd.Start()
+	if err != nil {
+		log.Fatalf("Error starting [%v]", err)
+	}
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatalf("Error running [%v]", err)
+	}
+
+}
+
+const (
+	BLKRRPART = 0x125f
+)
+
+// ReReadPartitionTable forces the kernel to re-read the partition table
+// on the disk.
+//
+// It is done via an ioctl call with request as BLKRRPART.
+func ReReadPartitionTable(d *os.File) error {
+	fd := d.Fd()
+	_, err := unix.IoctlGetInt(int(fd), BLKRRPART)
+	if err != nil {
+		return fmt.Errorf("Unable to re-read partition table: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

This adds a syslinux action, specifically for version `3.86`, others can be added later.

## Why is this needed

VMware in their infinite wisdom are pinned to a twelve year old bootloader... this allows us to deploy vSphere.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade

## Testing

```
docker run --privileged \
-e DEST_DISK=/dev/sdb \
-e SYSLINUX_VERSION=3.86 \
-e DEST_PARTITION=/dev/sdb1 \
thebsdbox/syslinux:1.0.0 
```