### PR TITLE
Fixes formatting issue

### DIFF
--- a/actions/image2disk/v1/main.go
+++ b/actions/image2disk/v1/main.go
@@ -25,5 +25,5 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Info("Successfully written [%s] to [%s]", img, disk)
+	log.Infof("Successfully written [%s] to [%s]", img, disk)
 }


### PR DESCRIPTION
## Description


```
time="2021-03-04T13:18:50Z" level=info msg="Successfully written [%s] to [%s]http://192.168.1.2/focal-server-cloudimg-amd64.raw/dev/sdb"
```
Wrong function is being called here `info` -> `infof`
<!--- Please describe what this PR is going to change -->

## Why is this needed

The success meeting is mis-formatted.

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
