### PR TITLE
cexec action

### DIFF
--- a/actions/cexec/v1/Dockerfile
+++ b/actions/cexec/v1/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:experimental
+
+# Build cexec
+FROM golang:1.15-alpine as cexec
+RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
+COPY . /go/src/github.com/thebsdbox/cexec/
+WORKDIR /go/src/github.com/thebsdbox/cexec
+ENV GO111MODULE=on
+RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
+    --mount=type=cache,sharing=locked,id=goroot,target=/root/.cache/go-build \
+    CGO_ENABLED=1 GOOS=linux go build -a -ldflags "-linkmode external -extldflags '-static' -s -w" -o cexec
+
+# Build final image
+FROM scratch
+COPY --from=cexec /go/src/github.com/thebsdbox/cexec/cexec .
+ENTRYPOINT ["/cexec"]

--- a/actions/cexec/v1/Makefile
+++ b/actions/cexec/v1/Makefile
@@ -1,0 +1,5 @@
+image:
+	docker buildx build  --platform linux/amd64 --push -t thebsdbox/cexec:0.0 .
+
+image-local:
+	docker buildx build  --platform linux/amd64 --load -t thebsdbox/cexec:0.0 .

--- a/actions/cexec/v1/README.md
+++ b/actions/cexec/v1/README.md
@@ -1,0 +1,45 @@
+---
+slug: cexec
+name: cexec
+tags: command
+maintainers: Dan Finneran <daniel.finneran@gmail.com>
+description: "This action can be used in a variety of ways, however its core functionality
+is the management of disks. The action parses the metadata and will partition, format and
+mount disks"
+version: v1.0.0
+createdAt: "2021-01-20T12:41:45.14Z"
+---
+
+The `cexec` action performs *execution* either within a [chroot](https://en.wikipedia.org/wiki/Chroot) environment
+or within the base filesystem. The primary use-case is being able to provision 
+files/an Operating System to disk and then being able to execute something that
+perhaps resides within that filesystem.
+
+```yaml
+actions:
+    - name: "Install Grub"
+      image: quay.io/tinkerbell-actions/cexec:v1.0.0
+      timeout: 90
+      environment:
+          BLOCK_DEVICE: /dev/sda3
+          FS_TYPE: ext4
+          CHROOT: y
+          CMD_LINE: "grub-install --root-directory=/boot /dev/sda"
+```
+
+In order to execute multiple commands (seperated by a semi-colon) we will
+need to leverage a shell. We do this by passing `sh -c` as a `DEFAULT_INTERPRETER`.
+This interpreter will then parse your commands.
+
+```yaml
+actions:
+    - name: "Update packages"
+      image: quay.io/tinkerbell-actions/cexec:v1.0.0
+      timeout: 90
+      environment:
+          BLOCK_DEVICE: /dev/sda3
+          FS_TYPE: ext4
+          CHROOT: y
+          DEFAULT_INTERPRETER: "/bin/sh -c"
+          CMD_LINE: "apt-get -y update; apt-get -y upgrade"
+```

--- a/actions/cexec/v1/go.mod
+++ b/actions/cexec/v1/go.mod
@@ -1,0 +1,9 @@
+module github.com/tinkerbell/hub/actions/cexec/v1
+
+go 1.15
+
+require (
+	github.com/sirupsen/logrus v1.7.0
+	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f // indirect
+)

--- a/actions/cexec/v1/go.sum
+++ b/actions/cexec/v1/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
+golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/actions/cexec/v1/main.go
+++ b/actions/cexec/v1/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Release - this struct contains the release information populated when building kexec
+var Release struct {
+	Version string
+	Build   string
+}
+
+const mountAction = "/mountAction"
+
+func main() {
+
+	fmt.Printf("CEXEC - Chroot Exec\n------------------------\n")
+
+	// Parse the environment variables that are passed into the action
+	blockDevice := os.Getenv("BLOCK_DEVICE")
+	filesystemType := os.Getenv("FS_TYPE")
+	chroot := os.Getenv("CHROOT")
+	defaultInterpreter := os.Getenv("DEFAULT_INTERPRETER")
+	cmdLine := os.Getenv("CMD_LINE")
+
+	var exitChroot func() error
+
+	if blockDevice == "" {
+		log.Fatalf("No Block Device speified with Environment Variable [BLOCK_DEVICE]")
+	}
+
+	// Create the /mountAction mountpoint (no folders exist previously in scratch container)
+	err := os.Mkdir(mountAction, os.ModeDir)
+	if err != nil {
+		log.Fatalf("Error creating the action Mountpoint [%s]", mountAction)
+	}
+
+	// Mount the block device to the /mountAction point
+	err = syscall.Mount(blockDevice, mountAction, filesystemType, 0, "")
+	if err != nil {
+		log.Fatalf("Mounting [%s] -> [%s] error [%v]", blockDevice, mountAction, err)
+	}
+	log.Infof("Mounted [%s] -> [%s]", blockDevice, mountAction)
+
+	if chroot != "" {
+		err = MountSpecialDirs()
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Infoln("Changing root before executing command")
+		exitChroot, err = Chroot(mountAction)
+		if err != nil {
+			log.Fatalf("Error changing root to [%s]", mountAction)
+		}
+	}
+
+	if defaultInterpreter != "" {
+		// Split the interpreter by space, in the event that the default intprepretter has flags.
+		di := strings.Split(defaultInterpreter, " ")
+		if len(di) == 0 {
+			log.Fatalln("Error parsing [\"DEFAULT_INTERPETER\"] [%s]", defaultInterpreter)
+		}
+		// Look for default shell intepreter
+		_, err = os.Stat(di[0])
+		if os.IsNotExist(err) {
+			log.Fatalf("Unable to find the [\"DEFAULT_INTERPETER\"] [%s], check chroot and interpreter path", defaultInterpreter)
+		}
+		di = append(di, cmdLine)
+		cmd := exec.Command(di[0], di[1:]...)
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+		var debugCMD = fmt.Sprintf("%s %v", di[0], di[1:])
+		err = cmd.Start()
+		if err != nil {
+			log.Fatalf("Error starting [%s] [%v]", debugCMD, err)
+		}
+		err = cmd.Wait()
+		if err != nil {
+			log.Fatalf("Error running [%s] [%v]", debugCMD, err)
+		}
+	} else {
+		// Format the cmdLine string into seperate execution tasks
+		commandLines := strings.Split(cmdLine, ";")
+		for x := range commandLines {
+			command := strings.Split(commandLines[x], " ")
+			cmd := exec.Command(command[0], command[1:]...)
+			cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+			var debugCMD = fmt.Sprintf("%s %v", command[0], command[1:])
+			err = cmd.Start()
+			if err != nil {
+				log.Fatalf("Error starting [%s] [%v]", debugCMD, err)
+			}
+			err = cmd.Wait()
+			if err != nil {
+				log.Fatalf("Error running [%s] [%v]", debugCMD, err)
+			}
+		}
+	}
+
+	if chroot != "" {
+		err = exitChroot()
+		if err != nil {
+			log.Errorf("Error exiting root from [%s], execution continuing", mountAction)
+		}
+	}
+}
+
+// Chroot handles changing the root, and returning a function to return back to the present directory
+func Chroot(path string) (func() error, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	root, err := os.Open(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := syscall.Chroot(path); err != nil {
+		root.Close()
+		return nil, err
+	}
+
+	// set the working directory inside container
+	if err := syscall.Chdir("/"); err != nil {
+		root.Close()
+		return nil, err
+	}
+
+	return func() error {
+		defer root.Close()
+		if err := root.Chdir(); err != nil {
+			return err
+		}
+		return syscall.Chroot(".")
+	}, nil
+}
+
+// MountSpecialDirs ensures that /dev /proc exist in the chroot
+func MountSpecialDirs() error {
+	// Mount dev
+	dev := filepath.Join(mountAction, "dev")
+
+	if err := syscall.Mount("none", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("Couldn't mount /dev to %v: %v", dev, err)
+	}
+
+	// Mount proc
+	proc := filepath.Join(mountAction, "proc")
+
+	if err := syscall.Mount("none", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

This adds `cexec` Chroot Exec

## Why is this needed

Allows for one-shot operations to run commands inside a newly written Operating system

Fixes: #

## How Has This Been Tested?

runs `ls` twice as the comand

```
# docker run -it --rm --privileged -e DEFAULT_INTERPRETER="/bin/sh -c" -e BLOCK_DEVICE=/dev/sdb1 -e FS_TYPE=ext4 -e CHROOT=y -e CMD_LINE="ls ; ls " thebsdbox/cexec:0.0
CEXEC - Chroot Exec
------------------------
INFO[0000] Mounted [/dev/sdb1] -> [/mountAction]
INFO[0000] Changing root before executing command
bin   dev  home  lib32	libx32	    media  mountAction	proc  run   snap  sys  usr
boot  etc  lib	 lib64	lost+found  mnt    opt		root  sbin  srv   tmp  var
bin   dev  home  lib32	libx32	    media  mountAction	proc  run   snap  sys  usr
boot  etc  lib	 lib64	lost+found  mnt    opt		root  sbin  srv   tmp  var
```


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
