### PR TITLE
[WIP] Do the equivalent of partprobe after writing in image2disk

### DIFF
--- a/actions/image2disk/v1/go.mod
+++ b/actions/image2disk/v1/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/sirupsen/logrus v1.7.0
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037
 )


### PR DESCRIPTION
## Description

Currently when using image2disk, if it creates new partitions on the underlying device those partitions are not accessible to following actions. 

## Why is this needed

This allows following actions to use any partitions created by this action.


## How Has This Been Tested?

Tested manually using the steps here: https://github.com/detiber/sandbox/tree/captee

Prior to the change the workflow would fail on a newly provisioned worker, after the workflow was successful on a newly provisioned worker.


## How are existing users impacted? What migration steps/scripts do we need?

This will allow users to more easily chain actions without having to insert an explicit partprobe or reboot 


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
