### PR TITLE
Aligns readme to environment vars

### DIFF
--- a/actions/archive2disk/v1/main.go
+++ b/actions/archive2disk/v1/main.go
@@ -15,7 +15,7 @@ const mountAction = "/mountAction"
 func main() {
 
 	fmt.Printf("Archive2Disk - Cloud archive streamer\n------------------------\n")
-	blockDevice := os.Getenv("BLOCK_DEVICE")
+	blockDevice := os.Getenv("DEST_DISK")
 	filesystemType := os.Getenv("FS_TYPE")
 	path := os.Getenv("DEST_PATH")
 
@@ -23,7 +23,7 @@ func main() {
 	archiveType := os.Getenv("ARCHIVE_TYPE")
 
 	if blockDevice == "" {
-		log.Fatalf("No Block Device speified with Environment Variable [BLOCK_DEVICE]")
+		log.Fatalf("No Block Device speified with Environment Variable [DEST_DISK]")
 	}
 
 	// Create the /mountAction mountpoint (no folders exist previously in scratch container)


### PR DESCRIPTION
## Description

Confusion between BLOCK_DEVICE and DEST_DISK.. Moved to DEST_DISK as we hit a partition not the raw block device.

## Why is this needed

It was confusing before. 

Fixes: #29

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
