### PR TITLE
Fix err check for metadata json unmarshal

### DIFF
--- a/actions/rootio/v1/pkg/types.go/metadata.go
+++ b/actions/rootio/v1/pkg/types.go/metadata.go
@@ -88,7 +88,7 @@ func RetreieveData() (*Metadata, error) {
 
 	jsonErr := json.Unmarshal(body, &mdata)
 	if jsonErr != nil {
-		return nil, err
+		return nil, jsonErr
 	}
 
 	return &mdata, nil


### PR DESCRIPTION
## Description

Fix err check for metadata json unmarshal

## Why is this needed

It is needed to see error if hw data is invalid.

Fixes: #

## How Has This Been Tested?
Local setup.


## How are existing users impacted? What migration steps/scripts do we need?
Users currently cannot see if there is an error related to metadata extraction.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
