### PR TITLE
cleanup image2disk package:

### DIFF
--- a/actions/image2disk/v1/pkg/image/image.go
+++ b/actions/image2disk/v1/pkg/image/image.go
@@ -18,8 +18,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var tick chan time.Time
-
 // WriteCounter counts the number of bytes written to it. It implements to the io.Writer interface
 // and we can pass this into io.TeeReader() which will report progress on each write cycle.
 type WriteCounter struct {
@@ -114,11 +112,6 @@ func UploadMultipartFile(client *http.Client, uri, key, path string, compressed 
 		} else {
 			// With compression run data through gzip writer
 			zipWriter := gzip.NewWriter(w)
-			if err != nil {
-				errchan <- fmt.Errorf("[ERROR] New gzip reader: %s", err)
-				return
-			}
-
 			// run an io.Copy on the disk into the zipWriter
 			if written, err := io.Copy(zipWriter, diskIn); err != nil {
 				errchan <- fmt.Errorf("error copying %s (%d bytes written): %v", path, written, err)
@@ -209,7 +202,7 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 	count, err := io.Copy(fileOut, out)
 	if err != nil {
 		ticker.Stop()
-		return fmt.Errorf("Error writing %d bytes to disk [%s] -> %v", count, destinationDevice, err)
+		return fmt.Errorf("error writing %d bytes to disk [%s] -> %v", count, destinationDevice, err)
 	}
 	fmt.Printf("\n")
 
@@ -217,11 +210,11 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 
 	// Do the equivalent of partprobe on the device
 	if err := fileOut.Sync(); err != nil {
-		return fmt.Errorf("Failed to sync the block device")
+		return fmt.Errorf("failed to sync the block device")
 	}
 
 	if err := unix.IoctlSetInt(int(fileOut.Fd()), unix.BLKRRPART, 0); err != nil {
-		return fmt.Errorf("Error re-probing the partitions for the specified device")
+		return fmt.Errorf("error re-probing the partitions for the specified device: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Cleaning up the image2disk package: 
- Removing unneeded code 
- Fixing fmt.Errorf() formating
- Don't swallow errors when they occur

## Why is this needed
Some errors are being lost due to bad formatting in addition to breaking go lints.
<!--- Link to issue you have raised -->

Fixes: #39

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reran the workflow and the errors are showing up again.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
