### PR TITLE
Check actions who needs to be re-build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    # thi is here becauase I am missing something big
+    # https://github.com/actions/checkout/issues/477
+    - run: git fetch origin
     - run: env
     - uses: cachix/install-nix-action@v12
       with:
@@ -19,6 +24,9 @@ jobs:
       name: Generate Artifact Hub manifests
     - run: make ci
       name: Ci checks
+      env:
+        GITHUB_BASE_REF: ${{ github.base_ref }}
+        GITHUB_HEAD_REF: ${{ github.head_ref }}
     - name: Deploy
       if: ${{ startsWith(github.ref, 'refs/heads/main') }}
       uses: peaceiris/actions-gh-pages@v3

--- a/hack/ci-check.sh
+++ b/hack/ci-check.sh
@@ -4,8 +4,6 @@
 
 set -eux
 
-env
-
 failed=0
 
 if ! git ls-files '*.sh' | xargs shfmt -l -d; then
@@ -26,3 +24,12 @@ test -z "$(git status --porcelain go.mod go.sum)"
 go vet ./...
 
 go test -v ./...
+
+# We check the list of actions to rebuild only for the entire pull_request.
+# The push event does not have a GITHUB_BASE_REF set. That's why here we use
+# that environment variable to figure out if it is a PR event or a commit push
+if [[ -z $GITHUB_BASE_REF ]]; then
+	echo "Skipping: This should only run on pull_request."
+	exit 0
+fi
+go run cmd/hub/main.go build --dry-run --git-ref "origin/$GITHUB_HEAD_REF..origin/$GITHUB_BASE_REF"


### PR DESCRIPTION
As part of the continuous integration workflows I would like to know
which actions will get build as soon as the pull request will be merged.
