### PR TITLE
Take image push option from the outside

### DIFF
--- a/cmd/hub/cmd/build.go
+++ b/cmd/hub/cmd/build.go
@@ -15,6 +15,7 @@ type buildOptions struct {
 	context       string
 	containerRepo string
 	dryRun        bool
+	push          bool
 	gitRef        string
 	platforms     string
 }
@@ -33,6 +34,7 @@ func init() {
 	buildCmd.PersistentFlags().StringVar(&buildOpts.context, "context", ".", "base path for the proposals repository in your local file system")
 	buildCmd.PersistentFlags().StringVar(&buildOpts.containerRepo, "container-repo", "quay.io/tinkerbell-actions", "repository to push the container images to")
 	buildCmd.PersistentFlags().BoolVar(&buildOpts.dryRun, "dry-run", false, "only show the modified actions")
+	buildCmd.PersistentFlags().BoolVar(&buildOpts.push, "push", false, "Push image to a registry")
 	buildCmd.PersistentFlags().StringVar(&buildOpts.gitRef, "git-ref", "HEAD^@", "the git commit or reference to compare to in the format of HEAD..<commit-id>")
 	// FIXME: For some odd reason linux/arm/v6 takes forever to build (> 20min), so I excluded it by default.
 	buildCmd.PersistentFlags().StringVar(&buildOpts.platforms, "platforms", "linux/amd64,linux/arm64,linux/arm/v7", "the target os and cpu architecture platforms for the container images")
@@ -85,7 +87,7 @@ func runBuild(opts *buildOptions) error {
 					Dockerfile: actionDockerfile,
 					Tag:        actionTag,
 					Platforms:  buildOpts.platforms,
-					Push:       true,
+					Push:       opts.push,
 					NoConsole:  false,
 				})
 				if err != nil {


### PR DESCRIPTION
Right now we have `--dry-run` to identify the actions we need to build
inside a particular git range.

We want to actually try to build the image but the `push` option was
fixed to `true`. This commit adds a `--push` option that has to be
specified in order to push the image to a registry.

This follows the same behavior buildx has.

Signed-off-by: Gianluca Arbezzano <ciao@gianarb.it>