### PR TITLE
Add action build as validation step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,16 +17,22 @@ jobs:
         platforms: all
     - name: Available platforms
       run: echo ${{ steps.qemu.outputs.platforms }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     # I opened this issue and a case on GitHub support
     # https://github.com/actions/checkout/issues/477 The support team answered
     # that right now there is not a clean way to take a diff because the
     # checkout action pulls the minimum it can.
     # I am watching this PR because it will help
     # https://github.com/actions/checkout/pull/155
-    - run: |
-        git clone -b ${{ github.head_ref }} ${{ github.event.pull_request.head.repo.html_url }} ${GITHUB_WORKSPACE}
-        git remote add upstream ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+    - name: fetch remote
+      run: |
+        git fetch origin
+        git remote add upstream ${{ github.event.pull_request.head.repo.html_url }}
         git fetch upstream
+        git branch -a
     - run: env
     - uses: cachix/install-nix-action@v12
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
-name: For each commit and PR
+name: For each pull request
 on:
-  push:
   pull_request:
 
 jobs:
@@ -9,13 +8,16 @@ jobs:
     env:
       CGO_ENABLED: 0
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    # thi is here becauase I am missing something big
-    # https://github.com/actions/checkout/issues/477
-    - run: git fetch origin
+    # I opened this issue and a case on GitHub support
+    # https://github.com/actions/checkout/issues/477 The support team answered
+    # that right now there is not a clean way to take a diff because the
+    # checkout action pulls the minimum it can.
+    # I am watching this PR because it will help
+    # https://github.com/actions/checkout/pull/155
+    - run: |
+        git clone -b ${{ github.head_ref }} ${{ github.event.pull_request.head.repo.html_url }} ${GITHUB_WORKSPACE}
+        git remote add upstream ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+        git fetch upstream
     - run: env
     - uses: cachix/install-nix-action@v12
       with:
@@ -25,8 +27,8 @@ jobs:
     - run: make ci
       name: Ci checks
       env:
-        GITHUB_BASE_REF: ${{ github.base_ref }}
-        GITHUB_HEAD_REF: ${{ github.head_ref }}
+        GITHUB_BASE_REF: ${ GITHUB_BASE_REF }
+        GITHUB_HEAD_REF: ${ GITHUB_HEAD_REF }
     - name: Deploy
       if: ${{ startsWith(github.ref, 'refs/heads/main') }}
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: For each pull request
 on:
   pull_request:
+  push:
 
 jobs:
   validation:
@@ -8,6 +9,14 @@ jobs:
     env:
       CGO_ENABLED: 0
     steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      id: qemu
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Available platforms
+      run: echo ${{ steps.qemu.outputs.platforms }}
     # I opened this issue and a case on GitHub support
     # https://github.com/actions/checkout/issues/477 The support team answered
     # that right now there is not a clean way to take a diff because the

--- a/actions/slurp/v1/main.go
+++ b/actions/slurp/v1/main.go
@@ -14,6 +14,7 @@ func main() {
 
 	fmt.Printf("SLURP - Upload the contents of a block device\n------------------------\n")
 	sourceDisk := os.Getenv("SOURCE_DISK")
+
 	destinationURL := os.Getenv("DEST_URL")
 	imageName := os.Getenv("IMG_NAME")
 	compressed := os.Getenv("COMPRESSED")

--- a/actions/slurp/v1/main.go
+++ b/actions/slurp/v1/main.go
@@ -14,7 +14,6 @@ func main() {
 
 	fmt.Printf("SLURP - Upload the contents of a block device\n------------------------\n")
 	sourceDisk := os.Getenv("SOURCE_DISK")
-
 	destinationURL := os.Getenv("DEST_URL")
 	imageName := os.Getenv("IMG_NAME")
 	compressed := os.Getenv("COMPRESSED")

--- a/hack/ci-check.sh
+++ b/hack/ci-check.sh
@@ -24,11 +24,12 @@ go vet ./...
 
 go test -v ./...
 
-# We check the list of actions to rebuild only for the entire pull_request.
-# The push event does not have a GITHUB_BASE_REF set. That's why here we use
-# that environment variable to figure out if it is a PR event or a commit push
+GIT_REF="remotes/upstream/$GITHUB_BASE_REF..$GITHUB_HEAD_REF"
+
+# GITHUB_BASE_REF gets populated only for the event pull_request.
+# But this job runs for push as well. In that case we want to assert the current commit.
+# It means that HEAD..HEAD~1 is enough.
 if [[ -z $GITHUB_BASE_REF ]]; then
-	echo "Skipping: This should only run on pull_request."
-	exit 0
+	GIT_REF="HEAD..HEAD~1"
 fi
-sudo go run cmd/hub/main.go build --git-ref "remotes/upstream/$GITHUB_BASE_REF..$GITHUB_HEAD_REF"
+sudo go run cmd/hub/main.go build --git-ref ${GIT_REF}

--- a/hack/ci-check.sh
+++ b/hack/ci-check.sh
@@ -31,4 +31,4 @@ if [[ -z $GITHUB_BASE_REF ]]; then
 	echo "Skipping: This should only run on pull_request."
 	exit 0
 fi
-go run cmd/hub/main.go build --dry-run --git-ref "remotes/upstream/$GITHUB_BASE_REF..$GITHUB_HEAD_REF"
+sudo go run cmd/hub/main.go build --git-ref "remotes/upstream/$GITHUB_BASE_REF..$GITHUB_HEAD_REF"

--- a/hack/ci-check.sh
+++ b/hack/ci-check.sh
@@ -5,7 +5,6 @@
 set -eux
 
 failed=0
-
 if ! git ls-files '*.sh' | xargs shfmt -l -d; then
 	failed=1
 fi
@@ -32,4 +31,4 @@ if [[ -z $GITHUB_BASE_REF ]]; then
 	echo "Skipping: This should only run on pull_request."
 	exit 0
 fi
-go run cmd/hub/main.go build --dry-run --git-ref "origin/$GITHUB_HEAD_REF..origin/$GITHUB_BASE_REF"
+go run cmd/hub/main.go build --dry-run --git-ref "remotes/upstream/$GITHUB_BASE_REF..$GITHUB_HEAD_REF"

--- a/hack/ci-check.sh
+++ b/hack/ci-check.sh
@@ -24,7 +24,7 @@ go vet ./...
 
 go test -v ./...
 
-GIT_REF="remotes/upstream/$GITHUB_BASE_REF..$GITHUB_HEAD_REF"
+GIT_REF="remotes/upstream/$GITHUB_HEAD_REF..remotes/origin/$GITHUB_BASE_REF"
 
 # GITHUB_BASE_REF gets populated only for the event pull_request.
 # But this job runs for push as well. In that case we want to assert the current commit.


### PR DESCRIPTION
## Description

The hub CLI build command can get git history only from PR coming from this repo. It does not work with a fork. This is because we fetch only the destination repository, not the one where the PR is coming from.

## Why is this needed

PR coming from fork should work