### PR TITLE
Add GitHub Action workflow to build and deploy actions

### DIFF
--- a/.github/workflows/cd-action-build.yaml
+++ b/.github/workflows/cd-action-build.yaml
@@ -1,0 +1,36 @@
+name: Build and push new actions on Quay.io
+on:
+  pull_request:
+  #push:
+  #  branches:
+  #    - main
+
+jobs:
+  validation:
+    runs-on: Ubuntu-20.04
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      id: qemu
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Available platforms
+      run: echo ${{ steps.qemu.outputs.platforms }}
+    - name: Login to quay.io
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: build and deploy
+      run: sudo ./hack/action-build-and-deploy.sh

--- a/actions/archive2disk/v1/main.go
+++ b/actions/archive2disk/v1/main.go
@@ -13,7 +13,6 @@ import (
 const mountAction = "/mountAction"
 
 func main() {
-
 	fmt.Printf("Archive2Disk - Cloud archive streamer\n------------------------\n")
 	blockDevice := os.Getenv("DEST_DISK")
 	filesystemType := os.Getenv("FS_TYPE")

--- a/hack/action-build-and-deploy.sh
+++ b/hack/action-build-and-deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../shell.nix
+# shellcheck shell=bash
+
+set -eux
+
+sudo go run cmd/hub/main.go build --push --git-ref "HEAD..HEAD~1"


### PR DESCRIPTION
Bootstrap a bash script that runs `hub build` to compile and push docker
images for the actions that changed on Quay.io

The workflow only runs on the push against the main branch.

Signed-off-by: Gianluca Arbezzano <ciao@gianarb.it>