### PR TITLE
Add GitHub Action workflow to build and deploy actions

### DIFF
--- a/.github/workflows/cd-action-build.yaml
+++ b/.github/workflows/cd-action-build.yaml
@@ -1,0 +1,34 @@
+name: Build and push new actions on Quay.io
+on:
+  pull_request:
+  #push:
+  #  branches:
+  #    - main
+
+jobs:
+  validation:
+    runs-on: Ubuntu-20.04
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      id: qemu
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Available platforms
+      run: echo ${{ steps.qemu.outputs.platforms }}
+    - run: env
+    # The ./hack/action-build-and-deploy.sh runs as sudo. It means that root is the user who needs to be authenticated agains quay.
+    # That's why we can't use the docker-login action here.
+    - run: echo "${{ secrets.QUAY_PWD }}" | sudo docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: build and deploy
+      run: ./hack/action-build-and-deploy.sh

--- a/actions/archive2disk/v1/main.go
+++ b/actions/archive2disk/v1/main.go
@@ -13,7 +13,6 @@ import (
 const mountAction = "/mountAction"
 
 func main() {
-
 	fmt.Printf("Archive2Disk - Cloud archive streamer\n------------------------\n")
 	blockDevice := os.Getenv("DEST_DISK")
 	filesystemType := os.Getenv("FS_TYPE")

--- a/hack/action-build-and-deploy.sh
+++ b/hack/action-build-and-deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../shell.nix
+# shellcheck shell=bash
+
+set -eux
+
+sudo go run cmd/hub/main.go build --push --git-ref "HEAD..HEAD~1"

--- a/shell.nix
+++ b/shell.nix
@@ -25,5 +25,7 @@ mkShell {
     shfmt
     shellcheck
     libseccomp
+    rootlesskit
+    runc
   ];
 }


### PR DESCRIPTION
Bootstrap a bash script that runs `hub build` to compile and push docker
images for the actions that changed on Quay.io

The workflow only runs on push against the main branch.

Signed-off-by: Gianluca Arbezzano <ciao@gianarb.it>