### PR TITLE
Add kexec debug log lines

### DIFF
--- a/actions/kexec/v1/Dockerfile
+++ b/actions/kexec/v1/Dockerfile
@@ -3,8 +3,8 @@
 # Build kexec
 FROM golang:1.15-alpine as kexec
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
-COPY . /go/src/github.com/thebsdbox/kexec/
-WORKDIR /go/src/github.com/thebsdbox/kexec
+COPY . /go/src/github.com/tinkerbell/hub/actions/kexec/v1/kexec/
+WORKDIR /go/src/github.com/tinkerbell/hub/actions/kexec/v1/kexec
 ENV GO111MODULE=on
 RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,sharing=locked,id=goroot,target=/root/.cache/go-build \
@@ -12,5 +12,5 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
 
 # Build final image
 FROM scratch
-COPY --from=kexec /go/src/github.com/thebsdbox/kexec/kexec .
+COPY --from=kexec /go/src/github.com/tinkerbell/hub/actions/kexec/v1/kexec/kexec .
 ENTRYPOINT ["/kexec"]

--- a/actions/kexec/v1/Makefile
+++ b/actions/kexec/v1/Makefile
@@ -1,3 +1,11 @@
+REGISTRY?=quay.io
+REPOSITORY?=tinkerbell-actions/kexec
+VERSION?=v1.0.0
+IMAGE=$(REGISTRY)/$(REPOSITORY):$(VERSION)
 
 image:
-	docker buildx build  --platform linux/amd64 --push -t thebsdbox/kexec:0.0 .
+	docker buildx build --load --platform linux/amd64 -t $(IMAGE) .
+
+push: image
+	docker push $(IMAGE)
+

--- a/actions/kexec/v1/cmd/kexec.go
+++ b/actions/kexec/v1/cmd/kexec.go
@@ -65,6 +65,7 @@ var kexecCmd = &cobra.Command{
 			if bootConfig == nil {
 				log.Fatal("No Kernel configuration passed in [KERNEL_PATH] and unable to parse [/boot/grub/grub.conf]")
 			}
+			log.Infof("Loaded boot config: %#v", bootConfig)
 			kernelMountPath = filepath.Join(mountAction, bootConfig.Kernel)
 			initrdMountPath = filepath.Join(mountAction, bootConfig.Initramfs)
 			// Overwrite the cmdline with what is found in grub.conf, unless something specific is added
@@ -86,11 +87,13 @@ var kexecCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
+		log.Infof("Running Kexec: kernel: %s, initrd: %s, cmdLine: %v", kernelMountPath, initrdMountPath, cmdLine)
 		// Load the kernel configuration into memory
 		err = unix.KexecFileLoad(int(kernel.Fd()), int(initrd.Fd()), cmdLine, 0)
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Info("Rebooting system")
 		// Call the unix reboot command with the kexec functionality
 		unix.Reboot(unix.LINUX_REBOOT_CMD_KEXEC)
 	},


### PR DESCRIPTION

## Description

Add debug log lines for `kexec` action. Debugging

## Why is this needed

When Kexec doesn't work, it'd be nice to know where in the process it breaks down.

## How Has This Been Tested?

> "Works on my machine"
> -Every pull request author

But really, I ran this in an effort to diagnose #57 
```
INFO[0000] Loaded boot config: &grub.Config{Name:"'Debian GNU/Linux' ", Kernel:"/boot/vmlinuz-4.19.0-16-cloud-amd64", Initramfs:"/boot/initrd.img-4.19.0-16-cloud-amd64", KernelArgs:"root=UUID=af5f8c82-a495-40e0-b3e6-f361abeec5a4 ro nosplash text biosdevname=0 net.ifnames=0 console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0 systemd.show_status=true", Multiboot:"", MultibootArgs:"", Modules:[]string(nil)} 
INFO[0000] Running Kexec: kernel: /mountAction/boot/vmlinuz-4.19.0-16-cloud-amd64, initrd: /mountAction/boot/initrd.img-4.19.0-16-cloud-amd64, cmdLine: root=UUID=af5f8c82-a495-40e0-b3e6-f361abeec5a4 ro nosplash text biosdevname=0 net.ifnames=0 console=tty0 console=ttyS0,115200 earlyprintk=ttyS0,115200 consoleblank=0 systemd.show_status=true 
INFO[0000] Rebooting system     
```


## How are existing users impacted? What migration steps/scripts do we need?

Existing users don't have much visibility when kexec doesn't work properly

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required) N/A
- [x] added unit or e2e tests N/A
- [x] provided instructions on how to upgrade N/A
