### PR TITLE
Fix CI for PRs from forks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+has nix && use nix
+dotenv_if_exists

--- a/.github/workflows/cd-action-build.yaml
+++ b/.github/workflows/cd-action-build.yaml
@@ -1,9 +1,6 @@
 name: Build and push new actions on Quay.io
 on:
   pull_request:
-  #push:
-  #  branches:
-  #    - main
 
 jobs:
   validation:
@@ -27,6 +24,7 @@ jobs:
     # The ./hack/action-build-and-deploy.sh runs as sudo. It means that root is the user who needs to be authenticated against quay.
     # That's why we can't use the docker-login action here.
     - name: Log in to Quay.io
+      if: ${{ startsWith(github.ref, 'refs/heads/main') }}
       run: echo "${{ secrets.QUAY_PWD }}" | sudo docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
 
     - name: Checkout code

--- a/.github/workflows/cd-action-build.yaml
+++ b/.github/workflows/cd-action-build.yaml
@@ -17,18 +17,27 @@ jobs:
       with:
         image: tonistiigi/binfmt:latest
         platforms: all
-    - name: Available platforms
+
+    - name: Show available platforms
       run: echo ${{ steps.qemu.outputs.platforms }}
-    - run: env
+
+    - name: Show env
+      run: env
+
     # The ./hack/action-build-and-deploy.sh runs as sudo. It means that root is the user who needs to be authenticated agains quay.
     # That's why we can't use the docker-login action here.
-    - run: echo "${{ secrets.QUAY_PWD }}" | sudo docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
+    - name: Log in to Quay.io
+      run: echo "${{ secrets.QUAY_PWD }}" | sudo docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
+
     - name: Checkout code
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: cachix/install-nix-action@v12
+
+    - name: Install nix
+      uses: cachix/install-nix-action@v12
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+
     - name: build and deploy
       run: ./hack/action-build-and-deploy.sh

--- a/.github/workflows/cd-action-build.yaml
+++ b/.github/workflows/cd-action-build.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Show env
       run: env
 
-    # The ./hack/action-build-and-deploy.sh runs as sudo. It means that root is the user who needs to be authenticated agains quay.
+    # The ./hack/action-build-and-deploy.sh runs as sudo. It means that root is the user who needs to be authenticated against quay.
     # That's why we can't use the docker-login action here.
     - name: Log in to Quay.io
       run: echo "${{ secrets.QUAY_PWD }}" | sudo docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,15 @@ jobs:
       with:
         image: tonistiigi/binfmt:latest
         platforms: all
-    - name: Available platforms
+
+    - name: Show available platforms
       run: echo ${{ steps.qemu.outputs.platforms }}
+
     - name: Checkout code
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
     # I opened this issue and a case on GitHub support
     # https://github.com/actions/checkout/issues/477 The support team answered
     # that right now there is not a clean way to take a diff because the
@@ -33,17 +36,24 @@ jobs:
         git fetch origin
         git remote add upstream ${{ github.event.pull_request.head.repo.html_url }}
         git fetch upstream
-    - run: env
-    - uses: cachix/install-nix-action@v12
+
+    - name: Show env
+      run: env
+
+    - name: Install nix
+      uses: cachix/install-nix-action@v12
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - run: make artifacthub/gen-manifests
-      name: Generate Artifact Hub manifests
-    - run: make ci
-      name: Ci checks
+
+    - name: Generate Artifact Hub manifests
+      run: make artifacthub/gen-manifests
+
+    - name: CI checks
+      run: make ci
       env:
         GITHUB_BASE_REF: ${ GITHUB_BASE_REF }
         GITHUB_HEAD_REF: ${ GITHUB_HEAD_REF }
+
     - name: Deploy
       if: ${{ startsWith(github.ref, 'refs/heads/main') }}
       uses: peaceiris/actions-gh-pages@v3

--- a/cmd/hub/cmd/generate.go
+++ b/cmd/hub/cmd/generate.go
@@ -19,7 +19,7 @@ var generateOpts = &generateOptions{}
 
 var generateCmd = &cobra.Command{
 	Use:   "generate [--context .]",
-	Short: "Generate the static webiste",
+	Short: "Generate the static website",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGenerate(generateOpts)
 	},


### PR DESCRIPTION
## Description

Main work is to fix the `Build and push new actions to Quay.io` action to not attempt to login to Quay from PRs from forks. PRs from forks don't have access to secrets and thus the docker login step fails.

I've also cleaned up the workflow files a bit so that each step has a name and an empty space around it so the files are easier to grok.

I've also added a .envrc so we can make use of direnv + nix-shell.

## Why is this needed

Should fix CI that is holding back #60.
