### PR TITLE
qemuimg2disk: fix builds for non-x86_64 (#67)

### DIFF
--- a/actions/qemuimg2disk/v1/Dockerfile
+++ b/actions/qemuimg2disk/v1/Dockerfile
@@ -50,7 +50,7 @@ FROM scratch as collect
 COPY --from=builder /bin/qemu-img /bin/qemu-img
 COPY --from=builder /bin/sh /bin/sh
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /lib/ld-musl-x86_64.so.1  /lib/ld-musl-x86_64.so.1
+COPY --from=builder /lib/ld-musl*  /lib/
 COPY --from=partprobe /src/partprobe /bin/partprobe
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
## Description
Make the qemuimg2disk build architecture agnostic

## Why is this needed

Fixes: #67 

## How Has This Been Tested?
Shouldn't break anything; `makte test-https` on x86_64 still works.

## How are existing users impacted? What migration steps/scripts do we need?

I don't think the image has been shipped out to users yet. Should only unbreak non-x86_64 users.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
