### PR TITLE
Ignore errors for the part probe

### DIFF
--- a/actions/image2disk/v1/pkg/image/image.go
+++ b/actions/image2disk/v1/pkg/image/image.go
@@ -115,7 +115,8 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 	}
 
 	if err := unix.IoctlSetInt(int(fileOut.Fd()), unix.BLKRRPART, 0); err != nil {
-		return fmt.Errorf("error re-probing the partitions for the specified device: %v", err)
+		// Ignore errors since it may be a partition, but log in case it's helpful
+		log.Errorf("error re-probing the partitions for the specified device: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
In cases where you're writing a file system image to an existing
partition, it's not really needed, but it's simpler and safer to just
ignore the error rather than try to figure out if it's a disk or
partition.

Signed-off-by: Steve Wills <steve@mouf.net>

## Description

Trying to write a file system image to an existing partition (`md`), I get an error on the re-probe. Seems safer and simpler to just ignore it.

## Why is this needed

In cases where you want to write a file system image rather than a disk image.

Fixes: N/A

## How Has This Been Tested?
In VMs

## How are existing users impacted? What migration steps/scripts do we need?

Should be no impact

## Checklist:

I have:

- [N/A] updated the documentation and/or roadmap (if required)
- [N/A] added unit or e2e tests
- [N/A] provided instructions on how to upgrade
