### PR TITLE
Align rootio with the current metadata format

### DIFF
--- a/actions/rootio/v1/cmd/rootio.go
+++ b/actions/rootio/v1/cmd/rootio.go
@@ -41,13 +41,12 @@ func init() {
 			log.Fatal(err)
 		}
 	} else {
-		metadata, err = types.RetreieveData()
+		metadata, err = types.RetrieveData()
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 	fmt.Printf("Succesfully parsed the MetaData, Found [%d] Disks\n", len(metadata.Storage.Disks))
-
 }
 
 // Execute - starts the command parsing process
@@ -145,11 +144,11 @@ func test() (*types.Metadata, error) {
 	byteValue, _ := ioutil.ReadAll(jsonFile)
 
 	// we initialize our Users array
-	var mdata types.Metadata
+	var w types.Wrapper
 
 	// we unmarshal our byteArray which contains our
 	// jsonFile's content into 'users' which we defined above
-	json.Unmarshal(byteValue, &mdata)
+	json.Unmarshal(byteValue, &w)
 
-	return &mdata, nil
+	return &w.Metadata, nil
 }

--- a/actions/rootio/v1/pkg/types.go/metadata.go
+++ b/actions/rootio/v1/pkg/types.go/metadata.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+// Wrapper is a top level struct to unmarshal the metadata.
+type Wrapper struct {
+	Metadata Metadata `json:"metadata"`
+}
+
 // Metadata struct
 // This is an auto generated struct taken from a metadata request
 type Metadata struct {
@@ -52,8 +57,8 @@ type Partitions struct {
 	Size   uint64 `json:"size"`
 }
 
-//RetreieveData -
-func RetreieveData() (*Metadata, error) {
+//RetrieveData -
+func RetrieveData() (*Metadata, error) {
 	metadataURL := os.Getenv("MIRROR_HOST")
 	if metadataURL == "" {
 		return nil, fmt.Errorf("Unable to discover the metadata server from environment variable [MIRROR_HOST]")
@@ -84,12 +89,13 @@ func RetreieveData() (*Metadata, error) {
 		return nil, err
 	}
 
-	var mdata Metadata
+	var w Wrapper
 
-	jsonErr := json.Unmarshal(body, &mdata)
+	jsonErr := json.Unmarshal(body, &w)
 	if jsonErr != nil {
 		return nil, jsonErr
 	}
+	mdata := w.Metadata
 
 	return &mdata, nil
 }

--- a/actions/rootio/v1/test/mbr.json
+++ b/actions/rootio/v1/test/mbr.json
@@ -1,37 +1,39 @@
 {
-  "crypted_root_password": "$6$password$u/Cn/tSGIYFtqv4AwZ9tjP1gMxjlvLHt3KO8zbK6ZnMn8anv6tSCo.XidktlU0MdRjWe3./lahF9FTMcnja9q.",
-  "hostname": "server001",
-  "operating_system_version": {
-    "distro": "debian",
-    "os_codename": "bullseye",
-    "os_slug": "debian_11",
-    "version": "11"
-  },
-  "storage": {
-    "disks": [
-      {
-        "device": "/dev/sdb",
-        "partitions": [
-          {
-            "label": "FAT32_ACTIVE",
-            "number": 1,
-            "size": 0
-          }
-        ],
-        "wipe_table": true
-      }
-    ],
-    "filesystems": [
-      {
-        "mount": {
-          "create": {
-            "options": ["-L", "ROOT"]
-          },
-          "device": "/dev/sdb1",
-          "format": "vfat",
-          "point": "/"
+  "metadata": {
+    "crypted_root_password": "$6$password$u/Cn/tSGIYFtqv4AwZ9tjP1gMxjlvLHt3KO8zbK6ZnMn8anv6tSCo.XidktlU0MdRjWe3./lahF9FTMcnja9q.",
+    "hostname": "server001",
+    "operating_system_version": {
+      "distro": "debian",
+      "os_codename": "bullseye",
+      "os_slug": "debian_11",
+      "version": "11"
+    },
+    "storage": {
+      "disks": [
+        {
+          "device": "/dev/sdb",
+          "partitions": [
+            {
+              "label": "FAT32_ACTIVE",
+              "number": 1,
+              "size": 0
+            }
+          ],
+          "wipe_table": true
         }
-      }
-    ]
+      ],
+      "filesystems": [
+        {
+          "mount": {
+            "create": {
+              "options": ["-L", "ROOT"]
+            },
+            "device": "/dev/sdb1",
+            "format": "vfat",
+            "point": "/"
+          }
+        }
+      ]
+    }
   }
 }

--- a/actions/rootio/v1/test/standard.json
+++ b/actions/rootio/v1/test/standard.json
@@ -1,57 +1,59 @@
 {
-  "crypted_root_password": "$6$password$u/Cn/tSGIYFtqv4AwZ9tjP1gMxjlvLHt3KO8zbK6ZnMn8anv6tSCo.XidktlU0MdRjWe3./lahF9FTMcnja9q.",
-  "hostname": "server001",
-  "operating_system_version": {
-    "distro": "debian",
-    "os_codename": "bullseye",
-    "os_slug": "debian_11",
-    "version": "11"
-  },
-  "storage": {
-    "disks": [
-      {
-        "device": "/dev/sdb",
-        "partitions": [
-          {
-            "label": "BIOS",
-            "number": 1,
-            "size": 4096
-          },
-          {
-            "label": "SWAP",
-            "number": 2,
-            "size": 3993600
-          },
-          {
-            "label": "ROOT",
-            "number": 3,
-            "size": 0
+  "metadata": {
+    "crypted_root_password": "$6$password$u/Cn/tSGIYFtqv4AwZ9tjP1gMxjlvLHt3KO8zbK6ZnMn8anv6tSCo.XidktlU0MdRjWe3./lahF9FTMcnja9q.",
+    "hostname": "server001",
+    "operating_system_version": {
+      "distro": "debian",
+      "os_codename": "bullseye",
+      "os_slug": "debian_11",
+      "version": "11"
+    },
+    "storage": {
+      "disks": [
+        {
+          "device": "/dev/sdb",
+          "partitions": [
+            {
+              "label": "BIOS",
+              "number": 1,
+              "size": 4096
+            },
+            {
+              "label": "SWAP",
+              "number": 2,
+              "size": 3993600
+            },
+            {
+              "label": "ROOT",
+              "number": 3,
+              "size": 0
+            }
+          ],
+          "wipe_table": true
+        }
+      ],
+      "filesystems": [
+        {
+          "mount": {
+            "create": {
+              "options": ["-L", "ROOT"]
+            },
+            "device": "/dev/sdb3",
+            "format": "ext4",
+            "point": "/"
           }
-        ],
-        "wipe_table": true
-      }
-    ],
-    "filesystems": [
-      {
-        "mount": {
-          "create": {
-            "options": ["-L", "ROOT"]
-          },
-          "device": "/dev/sdb3",
-          "format": "ext4",
-          "point": "/"
+        },
+        {
+          "mount": {
+            "create": {
+              "options": ["-L", "SWAP"]
+            },
+            "device": "/dev/sdb2",
+            "format": "swap",
+            "point": "none"
+          }
         }
-      },
-      {
-        "mount": {
-          "create": {
-            "options": ["-L", "SWAP"]
-          },
-          "device": "/dev/sdb2",
-          "format": "swap",
-          "point": "none"
-        }
-      }
-    ]
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Description

As it is now, rootio doesn't unmarshal the metadata returned for the node and doesn't perform any specified actions.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: https://github.com/tinkerbell/hub/issues/75

## How Has This Been Tested?
This has been tested by building a rootio with this change and running in the workflow.

## Checklist:

I have:

- updated and tested with the test json files
