### PR TITLE
Don't create, the device should exist

### DIFF
--- a/actions/image2disk/v1/pkg/image/image.go
+++ b/actions/image2disk/v1/pkg/image/image.go
@@ -68,7 +68,7 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 
 	var out io.Reader
 
-	fileOut, err := os.OpenFile(destinationDevice, os.O_CREATE|os.O_WRONLY, 0644)
+	fileOut, err := os.OpenFile(destinationDevice, os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Steve Wills <steve@mouf.net>

## Description

Change the flags to os.OpenFile so the path is not created.

## Why is this needed

image2disk will create a file in /dev if the device doesn't exist. This is not what is desired.

Fixes: #

## How Has This Been Tested?

Tested in my environment

## How are existing users impacted? What migration steps/scripts do we need?

Users can think image2disk succeeded in writing the image to disk when in reality it only created a file in /dev/ containing what the disk should contain.

## Checklist:

I have:

- [N/A] updated the documentation and/or roadmap (if required)
- [N/A] added unit or e2e tests
- [N/A] provided instructions on how to upgrade
