### PR TITLE
cexec: mount sysfs inside the chroot.

### DIFF
--- a/actions/cexec/v1/main.go
+++ b/actions/cexec/v1/main.go
@@ -142,7 +142,7 @@ func Chroot(path string) (func() error, error) {
 	}, nil
 }
 
-// MountSpecialDirs ensures that /dev /proc exist in the chroot
+// MountSpecialDirs ensures that /dev /proc /sys exist in the chroot
 func MountSpecialDirs() error {
 	// Mount dev
 	dev := filepath.Join(mountAction, "dev")
@@ -156,6 +156,13 @@ func MountSpecialDirs() error {
 
 	if err := syscall.Mount("none", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
 		return fmt.Errorf("Couldn't mount /proc to %v: %v", proc, err)
+	}
+
+	// Mount sys
+	sys := filepath.Join(mountAction, "sys")
+
+	if err := syscall.Mount("none", sys, "sysfs", syscall.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("Couldn't mount /sys to %v: %v", sys, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Mount sysfs inside the chroot

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #82

## How Has This Been Tested?
Locally. Before the change:

```
INFO[0000] Changing root before executing command
Sourcing file `/etc/default/grub'
Sourcing file `/etc/default/grub.d/init-select.cfg'
Generating grub configuration file ...
Unknown device "/dev/sda2": No such device
Unknown device "/dev/sda1": No such device
Unknown device "/dev/sda1": No such device
Unknown device "/dev/sda2": No such device

....
Found linux image: /boot/vmlinuz-5.4.0-99-generic
Found initrd image: /boot/initrd.img-5.4.0-99-generic
...

Unknown device "/dev/sda2": No such device
Unknown device "/dev/sda3": No such device
Unknown device "/dev/sda2": No such device
Unknown device "/dev/sda2": No such device
Cannot find list of partitions!  (Try mounting /sys.)
done
```

With the change:

```
INFO[0000] Changing root before executing command
Sourcing file `/etc/default/grub'
Sourcing file `/etc/default/grub.d/init-select.cfg'
Generating grub configuration file ...
Found linux image: /boot/vmlinuz-5.4.0-99-generic
Found initrd image: /boot/initrd.img-5.4.0-99-generic
done

```


## How are existing users impacted? What migration steps/scripts do we need?

Shouldn't have any impact on the existing users.

## Checklist:

I have:

- tested locally in my own setup.
