### PR TITLE
Extract disk wiping from disk partitioning

### DIFF
--- a/actions/rootio/v1/cmd/rootio.go
+++ b/actions/rootio/v1/cmd/rootio.go
@@ -26,6 +26,7 @@ var rootioCmd = &cobra.Command{
 }
 
 func init() {
+	rootioCmd.AddCommand(rootioWipe)
 	rootioCmd.AddCommand(rootioFormat)
 	rootioCmd.AddCommand(rootioPartition)
 	rootioCmd.AddCommand(rootioMount)
@@ -109,6 +110,29 @@ var rootioPartition = &cobra.Command{
 			} else {
 				err = storage.Partition(metadata.Instance.Storage.Disks[disk])
 			}
+			if err != nil {
+				log.Error(err)
+			}
+		}
+	},
+}
+
+var rootioWipe = &cobra.Command{
+	Use:   "wipe",
+	Short: "Use rootio to wipe disks based upon metadata",
+	Run: func(cmd *cobra.Command, args []string) {
+		for disk := range metadata.Instance.Storage.Disks {
+			err := storage.VerifyBlockDevice(metadata.Instance.Storage.Disks[disk].Device)
+			if err != nil {
+				log.Error(err)
+			}
+			err = storage.ExamineDisk(metadata.Instance.Storage.Disks[disk])
+			if err != nil {
+				log.Error(err)
+			}
+
+			err = storage.Wipe(metadata.Instance.Storage.Disks[disk])
+			log.Infoln("Wiping")
 			if err != nil {
 				log.Error(err)
 			}

--- a/actions/rootio/v1/pkg/storage/partition.go
+++ b/actions/rootio/v1/pkg/storage/partition.go
@@ -197,28 +197,3 @@ func MBRPartition(d types.Disk) error {
 	}
 	return nil
 }
-
-// Wipe will clean the table from a disk.
-func Wipe(d types.Disk) error {
-	disk, err := os.OpenFile(d.Device, os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	defer disk.Close()
-	bigBuff := make([]byte, 1024*1024*1024)
-	n, err := disk.Write(bigBuff)
-	if err != nil {
-		return err
-	}
-	log.Infof("Wrote [%d] bytes to [%s]", n, d.Device)
-	log.Infoln("Flushing writes to new partition")
-	err = disk.Sync()
-	if err != nil {
-		return err
-	}
-	err = disk.Close()
-	if err != nil {
-		return err
-	}
-	return nil
-}

--- a/actions/rootio/v1/pkg/storage/wipe.go
+++ b/actions/rootio/v1/pkg/storage/wipe.go
@@ -1,0 +1,33 @@
+package storage
+
+import (
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tinkerbell/hub/actions/rootio/v1/pkg/types.go"
+)
+
+// Wipe will clean the table from a disk.
+func Wipe(d types.Disk) error {
+	disk, err := os.OpenFile(d.Device, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer disk.Close()
+	bigBuff := make([]byte, 1024*1024*1024)
+	n, err := disk.Write(bigBuff)
+	if err != nil {
+		return err
+	}
+	log.Infof("Wrote [%d] bytes to [%s]", n, d.Device)
+	log.Infoln("Flushing writes to new partition")
+	err = disk.Sync()
+	if err != nil {
+		return err
+	}
+	err = disk.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Description
Extracting the Wipe functionality and add it as a dedicated command, where user can only wipe disks without any partitioning, using the metadata of the Hardware. 

<!--- Please describe what this PR is going to change -->

## Why is this needed
This is very helpful, when the provisioned machine, is gonna be used by some storage specific services or SDS operator, as some of those operators don't use disks that are in a specific status(for example if the disks have partitions, the storage operator would considered this disk is being used by anther software and wouldn't use and utilize it).
<!--- Link to issue you have raised -->

Fixes: https://github.com/tinkerbell/hub/issues/90

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was tested by using this commit and build an image out of it, where this image has been use as a workflow to de provision a machine. 

## How are existing users impacted? What migration steps/scripts do we need?
NA
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
