### PR TITLE
fix: Docs link for custom partitioning & raid

### DIFF
--- a/actions/rootio/v1/README.md
+++ b/actions/rootio/v1/README.md
@@ -13,7 +13,7 @@ createdAt: "2021-01-20T12:41:45.14Z"
 The below example will use the same action in three ways, to "partition" followed by "formating" and
 finally mounting the disks. All of the different commands below `partition`/`format`/`mount`, will
 have their actions determined by the contents of the storage section in the metadata refer to the
-[Customer Partitioning and RAID](https://metal.equinix.com/developers/docs/servers/custom-partitioning-raid/) documentation for more information.
+[Customer Partitioning and RAID](https://deploy.equinix.com/developers/docs/metal/storage/custom-partitioning-raid/) documentation for more information.
 
 ```yaml
 actions:


### PR DESCRIPTION
## Description

This PR fixes broken link for custom partitioning & raid in docs.

## Why is this needed

Broken Link

Fixes: #


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
