### PR TITLE
image2disk: support .bz2 extension

### DIFF
--- a/actions/image2disk/v1/pkg/image/image.go
+++ b/actions/image2disk/v1/pkg/image/image.go
@@ -127,7 +127,7 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 
 func findDecompressor(imageURL string, r io.Reader) (io.ReadCloser, error) {
 	switch filepath.Ext(imageURL) {
-	case ".bzip2":
+	case ".bzip2", ".bz2":
 		return ioutil.NopCloser(bzip2.NewReader(r)), nil
 	case ".gz":
 		reader, err := gzip.NewReader(r)


### PR DESCRIPTION
Added .bz2 extension support as both .bz2 and .bzip2 are commonly used file extensions for the same bzip2 compression format.

