### PR TITLE
bump go version, fix /dev/null permission after RW mount of /dev and add /dev/pts mount

### DIFF
--- a/actions/cexec/v1/Dockerfile
+++ b/actions/cexec/v1/Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:experimental
 
 # Build cexec
-FROM golang:1.15-alpine as cexec
-RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
+FROM golang:1.22.0-bookworm as cexec
 COPY . /go/src/github.com/thebsdbox/cexec/
 WORKDIR /go/src/github.com/thebsdbox/cexec
 ENV GO111MODULE=on
@@ -12,5 +11,5 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
 
 # Build final image
 FROM scratch
-COPY --from=cexec /go/src/github.com/thebsdbox/cexec/cexec .
-ENTRYPOINT ["/cexec"]
+COPY --from=cexec /go/src/github.com/thebsdbox/cexec/cexec /usr/bin/cexec
+ENTRYPOINT ["/usr/bin/cexec"]


### PR DESCRIPTION
## Description
<!--- Please describe what this PR is going to change -->
This PR fixes the following problem: https://github.com/tinkerbell/hook/issues/142

When this merged, one can run apt update with cexec on Ubuntu 22.04 with the following CMD_LINE:
```
CMD_LINE: echo 'nameserver IPOFYOURNAMESERVER' > /etc/resolv.conf && export NEEDRESTART_SUSPEND=true && apt -y update && apt install -y nfs-common open-iscsi....
```

## Why is this needed
Currently, due to the 0660 /dev/null, apt update cannot run. See details of the issue in the linked ticket.

Fixes: https://github.com/tinkerbell/hook/issues/142

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've built a cexec container and successfully installed several packages into an Ubuntu 22.04 in EKS Anywhere bare metal(using tinkerbell).

## How are existing users impacted? What migration steps/scripts do we need?
While this may not be the most elegant solution (we possibly should fix hook's kernel to have proper /dev/null permission on devtmpfs mount) it allows tinkerbell/cexec users to run apt (and any other commands that needs user writable /dev/null) in a backwards compatible way (it does not break anything).
<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [-] added unit or e2e tests
- [X] provided instructions on how to upgrade
