### PR TITLE
oci2disk: fix: update readme to new oras

### DIFF
--- a/oci2disk/README.md
+++ b/oci2disk/README.md
@@ -14,7 +14,8 @@ as this will simplify the process of creating a new "artifact" that can be used 
 The below example will push a `debian` image to a registry:
 
 ```
-oras push  192.168.0.173/test/debian:raw.gz --manifest-config /dev/null:application/vnd.acme.rocket.config ./debian.raw.gz --insecure
+# defaults to expected layer media-type of application/vnd.oci.image.layer.v1.tar
+oras push 192.168.0.173/test/debian:raw.gz ./debian.raw.gz --insecure
 ```
 
 We can then use this image by referring too it with teh `IMG_URL` environment variable.


### PR DESCRIPTION
## Description

This pr updates the readme of oci2disk to use the updated oras command. oras removed the `--manifest-config` flag and the default media type is [expected](https://github.com/tinkerbell/actions/blob/66e4fc9a20d946bc217ada425717e20cb9570657/oci2disk/image/image.go#L60-L61).

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
