### PR TITLE
cexec: grab the mountpoints using the metadata service if requested.

### DIFF
--- a/cexec/README.md
+++ b/cexec/README.md
@@ -40,6 +40,22 @@ actions:
       DEBIAN_FRONTEND: noninteractive
 ```
 
+If you want to use the mountpoints provided by metadata, replace the env variables called `BLOCK_DEVICE` and `FS_TYPE`
+by `MIRROR_HOST` and `METADATA_SERVICE_PORT` (if required).
+
+```yaml
+actions:
+- name: Use cexec to check the mount points using the metedata
+  image: registry.ring0:5000/tinkerbell/actions/cexec:dev
+  timeout: 3601
+  environment:
+      MIRROR_HOST: 192.168.3.5
+      METADATA_SERVICE_PORT: 7172
+      CHROOT: y
+      DEFAULT_INTERPRETER: "/bin/bash -c"
+      CMD_LINE: "df -h"
+```
+
 ### Environment variables and CLI flags
 
 All options can be set either via environment variables or CLI flags.
@@ -47,13 +63,15 @@ CLI flags take precedence over environment variables, which take precedence over
 
 | Env variable | Flag | Type | Default Value | Required | Description |
 |--------------|------|------|---------------|----------|-------------|
-| `BLOCK_DEVICE` | `--block-device` | string | "" | yes | The block device to mount. |
-| `FS_TYPE` | `--fs-type` | string | "" | yes | The filesystem type of the block device. |
+| `BLOCK_DEVICE` | `--block-device` | string | "" | no | The block device to mount. |
+| `FS_TYPE` | `--fs-type` | string | "" | no | The filesystem type of the block device. |
 | `CHROOT` | `--chroot` | string | "" | no | If set to `y` (or a non empty string), the Action will execute the given command within a chroot environment. This option is DEPRECATED. Future versions will always chroot. |
 | `CMD_LINE` | `--cmd-line` | string | "" | yes | The command to execute. |
 | `DEFAULT_INTERPRETER` | `--default-interpreter` | string | "" | no | The default interpreter to use when executing commands. This is useful when you need to execute multiple commands. |
 | `UPDATE_RESOLV_CONF` | `--update-resolv-conf` | boolean | false | no | If set to `true`, the cexec Action will update the `/etc/resolv.conf` file within the chroot environment with the `/etc/resolv.conf` from the host. |
 | `JSON_OUTPUT` | `--json-output` | boolean | true | no | If set to `true`, the cexec Action will log output in JSON format. The defaults to `true`. If set to `false`, the cexec Action will log output in plain text format. |
+| `MIRROR_HOST` | `--mirror-host` | string | "" | no | The hostname of the metadata service. If defined, `.hardware.spec.metadata.storage.filesystems` will be used instead of `BLOCK_DEVICE` |
+| `METADATA_SERVICE_PORT` | `--metadata-service-port | int | 7172 | no | The port of the metadata service. |
 
 Any environment variables you set on the Action will be available to the command you execute.
 For example, if you set `DEBIAN_FRONTEND: noninteractive` as an environment variable, it will be available to the command you execute.

--- a/cexec/main.go
+++ b/cexec/main.go
@@ -14,6 +14,8 @@ import (
 	"syscall"
 
 	"github.com/peterbourgon/ff/v3"
+
+	"github.com/tinkerbell/actions/rootio/storage"
 )
 
 const (
@@ -22,27 +24,35 @@ const (
 )
 
 type settings struct {
-	blockDevice        string
-	filesystemType     string
-	chroot             string
-	defaultInterpreter string
-	cmdLine            string
-	updateResolvConf   bool
+	blockDevice         string
+	filesystemType      string
+	chroot              string
+	defaultInterpreter  string
+	cmdLine             string
+	updateResolvConf    bool
+	mirrorHost          string
+	metadataServicePort int
 }
 
+var metadata *storage.Metadata
+
 func main() {
+	var err error
+
 	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGHUP, syscall.SIGTERM)
 	defer done()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	fs := flag.NewFlagSet("cexec", flag.ExitOnError)
 	s := settings{}
-	fs.StringVar(&s.blockDevice, "block-device", "", "block device to mount (required)")
-	fs.StringVar(&s.filesystemType, "fs-type", "", "filesystem type (required)")
+	fs.StringVar(&s.blockDevice, "block-device", "", "block device to mount")
+	fs.StringVar(&s.filesystemType, "fs-type", "", "filesystem type")
 	fs.StringVar(&s.chroot, "chroot", "", "use chroot environment to run given command (deprecated)")
 	fs.StringVar(&s.defaultInterpreter, "default-interpreter", "", "default interpreter (optional)")
 	fs.StringVar(&s.cmdLine, "cmd-line", "", "command line to execute (required)")
 	fs.BoolVar(&s.updateResolvConf, "update-resolv-conf", false, "update /etc/resolv.conf in chroot environment (optional)")
+	fs.StringVar(&s.mirrorHost, "mirror-host", "", "Metadata host (optional)")
+	fs.IntVar(&s.metadataServicePort, "metadata-service-port", 7172, "Metadata service port (optional)")
 	jsonLogger := fs.Bool("json-outout", true, "enable json output for logging")
 
 	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarNoPrefix()); err != nil {
@@ -56,6 +66,15 @@ func main() {
 		fmt.Fprintln(os.Stderr)
 		fs.Usage()
 		os.Exit(20)
+	}
+
+	if os.Getenv("MIRROR_HOST") != "" {
+		metadata, err = storage.RetrieveData()
+		if err != nil {
+			logger.Error(err.Error())
+			os.Exit(20)
+		}
+		fmt.Printf("Successfully parsed the MetaData, Found [%d] Disks\n", len(metadata.Instance.Storage.Disks))
 	}
 
 	// TODO(jacobweinstock): add field validations for the settings struct.
@@ -72,6 +91,8 @@ func main() {
 		"cmd-line", s.cmdLine,
 		"json-output", *jsonLogger,
 		"update-resolv-conf", s.updateResolvConf,
+		"mirror-host", s.mirrorHost,
+		"metadata-service-port", s.metadataServicePort,
 	)
 
 	if err := s.cexec(ctx, logger); err != nil {
@@ -82,11 +103,13 @@ func main() {
 
 func (s settings) checkRequiredFields() []string {
 	var missingFields []string
-	if s.blockDevice == "" {
-		missingFields = append(missingFields, "block-device")
-	}
-	if s.filesystemType == "" {
-		missingFields = append(missingFields, "fs-type")
+	if s.mirrorHost == "" {
+		if s.blockDevice == "" {
+			missingFields = append(missingFields, "block-device")
+		}
+		if s.filesystemType == "" {
+			missingFields = append(missingFields, "fs-type")
+		}
 	}
 	if s.cmdLine == "" {
 		missingFields = append(missingFields, "cmd-line")
@@ -95,29 +118,60 @@ func (s settings) checkRequiredFields() []string {
 }
 
 func (s settings) cexec(ctx context.Context, log *slog.Logger) error {
+	var err error
 	log.Info("CEXEC - Chroot Exec")
 
-	if s.blockDevice == "" {
-		return errors.New("no Block Device speified with Environment Variable [BLOCK_DEVICE]")
-	}
-
 	// Create the /mountAction mountpoint (no folders exist previously in scratch container)
-	if err := os.Mkdir(mountAction, os.ModeDir); err != nil {
+	if err = os.Mkdir(mountAction, os.ModeDir); err != nil {
 		return fmt.Errorf("error creating the mount point [%s], error: %w", mountAction, err)
 	}
 
-	// Mount the block device to the /mountAction point
-	if err := syscall.Mount(s.blockDevice, mountAction, s.filesystemType, 0, ""); err != nil {
-		return fmt.Errorf("error mounting [%s] -> [%s], error: %v", s.blockDevice, mountAction, err)
-	}
-	defer func() {
-		if err := syscall.Unmount(mountAction, 0); err != nil {
-			log.Error("error unmounting device", "source", s.blockDevice, "destination", mountAction, "error", err)
-		} else {
-			log.Info("unmounted device successfully", "source", s.blockDevice, "destination", mountAction)
+	if metadata != nil && len(metadata.Instance.Storage.Filesystems) > 0 {
+		// Mount the block device according to the metadata to the /mountAction point
+		log.Info("Using the Block Devices from metadata")
+
+		for _, fileSystem := range metadata.Instance.Storage.Filesystems {
+			if fileSystem.Mount.Format != "SWAP" {
+				fileSystem.Mount.Point = fmt.Sprintf("%s/%s", mountAction, fileSystem.Mount.Point)
+				err = os.MkdirAll(fileSystem.Mount.Point, 0755)
+				if err != nil {
+					log.Error("error creating directory mountpoint", "directory", fileSystem.Mount.Point)
+				} else {
+					err := storage.Mount(fileSystem)
+					if err != nil {
+						log.Error(err.Error())
+					} else {
+						defer func() {
+							if err := syscall.Unmount(fileSystem.Mount.Point, 0); err != nil {
+								log.Error("error unmounting device", "source", fileSystem.Mount.Device, "destination", fileSystem.Mount.Point, "error", err)
+							} else {
+								log.Info("unmounted device successfully", "source", fileSystem.Mount.Device, "destination", fileSystem.Mount.Point)
+							}
+						}()
+					}
+				}
+			}
 		}
-	}()
-	log.Info("mounted device successfully", "source", s.blockDevice, "destination", mountAction)
+	} else {
+		// Mount the block device from env to the /mountAction point
+		log.Info("Using the Block Device from env")
+
+		if s.blockDevice == "" {
+			return errors.New("no Block Device specified with Environment Variable [BLOCK_DEVICE]")
+		}
+
+		if err := syscall.Mount(s.blockDevice, mountAction, s.filesystemType, 0, ""); err != nil {
+			return fmt.Errorf("error mounting [%s] -> [%s], error: %v", s.blockDevice, mountAction, err)
+		}
+		defer func() {
+			if err := syscall.Unmount(mountAction, 0); err != nil {
+				log.Error("error unmounting device", "source", s.blockDevice, "destination", mountAction, "error", err)
+			} else {
+				log.Info("unmounted device successfully", "source", s.blockDevice, "destination", mountAction)
+			}
+		}()
+		log.Info("mounted device successfully", "source", s.blockDevice, "destination", mountAction)
+	}
 
 	if s.chroot != "" {
 		if s.updateResolvConf {


### PR DESCRIPTION
## Description

At the moment, `cexec` can only mount one block device to create the chroot environment. Moreover, the target block device needs to be provided.
This PR allows `cexec` to query the metadata service in order to mount the whole filesystems declared in the `Hradware` object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Both retro-compatibility and the new feature have been tested.
I used this template:

```yaml
---
apiVersion: tinkerbell.org/v1alpha1
kind: Template
metadata:
  name: cexec-testing
  namespace: tinkerbell-system
spec:
  data: |
    version: '0.1'
    name: cexec_testing
    global_timeout: 6000
    tasks:
    - name: "Partitioning and checking"
      worker: "{{.machine_mac}}"
      volumes:
       - /sys:/sys
       - /dev:/dev
       - /dev/console:/dev/console
       - /lib/firmware:/lib/firmware:ro
      actions:
      - name: "disk-wipe-partition"
        image: registry.ring0:5000/tinkerbell/actions/rootio:latest
        timeout: 90
        command: ["partition"]
        environment:
          MIRROR_HOST: 192.168.3.5
          METADATA_SERVICE_PORT: 7172
      - name: "format"
        image: registry.ring0:5000/tinkerbell/actions/rootio:latest
        timeout: 90
        command: ["format"]
        environment:
          MIRROR_HOST: 192.168.3.5
          METADATA_SERVICE_PORT: 7172
      - name: "mount"
        image: registry.ring0:5000/tinkerbell/actions/rootio:latest
        timeout: 90
        command: ["mount"]
        environment:
          MIRROR_HOST: 192.168.3.5
          METADATA_SERVICE_PORT: 7172

      - name: Use cexec to check the mount points using the metadata
        image: registry.ring0:5000/tinkerbell/actions/cexec:dev
        timeout: 3601
        environment:
          MIRROR_HOST: 192.168.3.5
          METADATA_SERVICE_PORT: 7172
          CHROOT: y
          DEFAULT_INTERPRETER: "/bin/bash -c"
          CMD_LINE: df -h

      - name: Use cexec to check the mount points using the env
        image: registry.ring0:5000/tinkerbell/actions/cexec:dev
        timeout: 3601
        environment:
          BLOCK_DEVICE: /dev/sda3
          FS_TYPE: ext4
          CHROOT: y
          DEFAULT_INTERPRETER: "/bin/bash -c"
          CMD_LINE: df -h
---
apiVersion: tinkerbell.org/v1alpha1
kind: Workflow
metadata:
  name: cexec-testing
  namespace: tinkerbell-system
spec:
 templateRef: cexec-testing
 hardwareRef: node-1
 hardwareMap:
   machine_mac: 10:66:6a:07:8d:01
---
apiVersion: tinkerbell.org/v1alpha1
kind: Hardware
metadata:
  name: node-1
  namespace: tinkerbell-system
spec:
  disks:
    - device: /dev/sda
  interfaces:
    - dhcp:
        arch: x86_64
        hostname: node-1.ring0
        ip:
          address: 192.168.3.150
          netmask: 255.255.255.0
        lease_time: 86400
        mac: 10:66:6a:07:8d:01
        name_servers:
          - 192.168.3.7
        uefi: true
      netboot:
        allowPXE: true
        allowWorkflow: true
  metadata:
    instance:
      crypted_root_password:
      hostname: node-1
      operating_system:
        distro: ubuntu
        image_tag: noble
        os_slug: ubuntu-noble
        slug: noble
        version: "24.04"
      ssh_keys:
      storage:
        disks:
        - wipe_table: true
          device: /dev/sda
          partitions:
          - label: EFI
            number: 1
            size: 1228800
          - label: SWAP
            number: 2
            size: 1228800
          - label: ROOTFS
            number: 3
            size: 0
        filesystems:
        - mount:
            create:
              options:
            device: /dev/sda2
            format: swap
            point:
        - mount:
            create:
              options:
            device: /dev/sda3
            format: ext4
            point: "/"
        - mount:
            create:
              options:
            device: /dev/sda1
            format: vfat
            point: "/boot"
  userData:
```

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->
There is no migration to plan. The former behaviour is still possible.
In order to use the new feature, the `README.md` has been updated too.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [x] provided instructions on how to upgrade
