### PR TITLE
oci2disk: add the ability to pass the compression algorithm via the C…

### DIFF
--- a/oci2disk/README.md
+++ b/oci2disk/README.md
@@ -11,29 +11,57 @@ as this will simplify the process of creating a new "artifact" that can be used 
 
 * Pushing an OS image to a Harbor Registry with oras *
 
-The below example will push a `debian` image to a registry:
+The below example will push a gzip-compressed `debian` image to a registry:
 
-```
-# defaults to expected layer media-type of application/vnd.oci.image.layer.v1.tar
-oras push 192.168.0.173/test/debian:raw.gz ./debian.raw.gz --insecure
+```bash
+# Push the compressed image (the filename doesn't need to include the compression extension)
+oras push 192.168.0.173/test/debian:latest ./debian.raw.gz --insecure
 ```
 
-We can then use this image by referring too it with teh `IMG_URL` environment variable.
+We can then use this image by referring to it with the `IMG_URL` environment variable
+and specifying the compression algorithm via `COMPRESSED`:
 
 ```yaml
 actions:
 - name: "stream-debian-image"
-    image: quay.io/tinkerbell/actions/oci2disk:latest
-    timeout: 600
-    environment:
-      DEST_DISK: /dev/nvme0n1
-      IMG_URL: "192.168.0.173/test/debian:raw.gz"
-      COMPRESSED: true
+  image: quay.io/tinkerbell/actions/oci2disk:latest
+  timeout: 600
+  environment:
+    DEST_DISK: /dev/nvme0n1
+    IMG_URL: "192.168.0.173/test/debian:latest"
+    COMPRESSED: gz
 ```
 
-## Compression format supported:
+## Environment Variables
 
-- bzip2 (`.bzip2`)
-- gzip (`.gz`)
-- xz (`.xz`)
-- xs (`.xs`)
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DEST_DISK` | Target block device (e.g., `/dev/nvme0n1`) | Yes |
+| `IMG_URL` | OCI image reference (e.g., `registry/repo:tag`) | Yes |
+| `COMPRESSED` | Compression algorithm (see below) | No |
+
+## Compression Formats Supported
+
+| Value                   | Format |
+|-------------------------|--------|
+| `gz` or `gzip`          | gzip |
+| `xz`                    | xz |
+| `zstd` or `zst` or `zs` | Zstandard |
+| `bzip2`                 | bzip2 |
+| `true`                  | Auto-detect from image tag extension (backward compatible) |
+| (empty)                 | No compression |
+
+### Recommended Usage
+
+Specify the compression algorithm explicitly:
+
+```yaml
+COMPRESSED: gz
+```
+
+### Backward Compatibility
+
+For backward compatibility, `COMPRESSED: true` is still supported and will detect
+the compression format from the image tag extension (e.g., `image:tag.gz` → gzip).
+However, explicitly specifying the compression algorithm is preferred as it doesn't
+require encoding the compression type in the image tag.

--- a/oci2disk/image/image.go
+++ b/oci2disk/image/image.go
@@ -35,10 +35,59 @@ func (wc *WriteCounter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-// Write will pull an image and write it to local storage device
-// with compress set to true it will use gzip compression to expand the data before
-// writing to an underlying device.
-func Write(sourceImage, destinationDevice string, compressed bool) error {
+type Compression int
+
+const (
+	CompressionNone Compression = iota
+	CompressionGzip
+	CompressionXZ
+	CompressionZstd
+	CompressionBzip2
+)
+
+// ParseCompression parses a compression string into a Compression type.
+// Accepts: gz, gzip, xz, zstd, zst, bzip2
+// For backward compatibility: "true" detects compression from the imageURL extension.
+// Empty string or "false" returns CompressionNone.
+func ParseCompression(s string, imageURL string) Compression {
+	switch s {
+	case "gz", "gzip":
+		return CompressionGzip
+	case "xz":
+		return CompressionXZ
+	case "zstd", "zst", "zs":
+		return CompressionZstd
+	case "bzip2":
+		return CompressionBzip2
+	case "true":
+		// Backward compatibility: detect from image URL extension
+		return detectCompressionFromURL(imageURL)
+	default:
+		return CompressionNone
+	}
+}
+
+// detectCompressionFromURL detects compression type from URL file extension.
+// This provides backward compatibility with COMPRESSED=true.
+func detectCompressionFromURL(imageURL string) Compression {
+	switch filepath.Ext(imageURL) {
+	case ".bzip2":
+		return CompressionBzip2
+	case ".gz":
+		return CompressionGzip
+	case ".xz":
+		return CompressionXZ
+	case ".zstd", ".zst", ".zs":
+		return CompressionZstd
+	default:
+		return CompressionNone
+	}
+}
+
+// Write will pull an image and write it to local storage device.
+// If compression is not CompressionNone, it will decompress the data before
+// writing to the underlying device.
+func Write(sourceImage, destinationDevice string, compression Compression) error {
 	ctx := context.Background()
 	client := http.DefaultClient
 	opts := docker.ResolverOptions{}
@@ -60,7 +109,7 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 	customMediaType := "application/vnd.oci.image.layer.v1.tar"
 	allowedMediaTypes := []string{customMediaType}
 
-	f := NewDiskImageStore(sourceImage, compressed, fileOut)
+	f := NewDiskImageStore(compression, fileOut)
 
 	log.Infof("Beginning write of image [%s] to disk [%s]", filepath.Base(sourceImage), destinationDevice)
 	pullOpts := []oras.PullOpt{
@@ -87,29 +136,31 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 	return nil
 }
 
-func findDecompressor(imageURL string, r io.Reader) (io.ReadCloser, error) {
-	switch filepath.Ext(imageURL) {
-	case ".bzip2":
+func newDecompressor(compression Compression, r io.Reader) (io.ReadCloser, error) {
+	switch compression {
+	case CompressionBzip2:
 		return io.NopCloser(bzip2.NewReader(r)), nil
-	case ".gz":
+	case CompressionGzip:
 		reader, err := gzip.NewReader(r)
 		if err != nil {
 			return nil, fmt.Errorf("[ERROR] New gzip reader: %w", err)
 		}
 		return reader, nil
-	case ".xz":
+	case CompressionXZ:
 		reader, err := xz.NewReader(r)
 		if err != nil {
 			return nil, fmt.Errorf("[ERROR] New xz reader: %w", err)
 		}
 		return io.NopCloser(reader), nil
-	case ".zs":
+	case CompressionZstd:
 		reader, err := zstd.NewReader(r)
 		if err != nil {
 			return nil, fmt.Errorf("[ERROR] New zs reader: %w", err)
 		}
 		return reader.IOReadCloser(), nil
+	case CompressionNone:
+		return io.NopCloser(r), nil
 	}
 
-	return nil, fmt.Errorf("unknown compression suffix [%s]", filepath.Ext(imageURL))
+	return nil, fmt.Errorf("[ERROR] Unknown compression type: %d", compression)
 }

--- a/oci2disk/image/image.go
+++ b/oci2disk/image/image.go
@@ -46,7 +46,7 @@ const (
 )
 
 // ParseCompression parses a compression string into a Compression type.
-// Accepts: gz, gzip, xz, zstd, zst, bzip2
+// Accepts: gz, gzip, xz, zstd, zst, zs, bzip2
 // For backward compatibility: "true" detects compression from the imageURL extension.
 // Empty string or "false" returns CompressionNone.
 func ParseCompression(s string, imageURL string) Compression {
@@ -71,14 +71,14 @@ func ParseCompression(s string, imageURL string) Compression {
 // This provides backward compatibility with COMPRESSED=true.
 func detectCompressionFromURL(imageURL string) Compression {
 	switch filepath.Ext(imageURL) {
-	case ".bzip2":
-		return CompressionBzip2
-	case ".gz":
+	case ".gz", ".gzip":
 		return CompressionGzip
 	case ".xz":
 		return CompressionXZ
 	case ".zstd", ".zst", ".zs":
 		return CompressionZstd
+	case ".bzip2":
+		return CompressionBzip2
 	default:
 		return CompressionNone
 	}

--- a/oci2disk/image/image_test.go
+++ b/oci2disk/image/image_test.go
@@ -42,50 +42,82 @@ func xzReader(t *testing.T) io.Reader {
 	return rdata
 }
 
-func Test_findDecompressor(t *testing.T) {
+func rawReader(t *testing.T) io.Reader {
+	t.Helper()
+	return strings.NewReader("YourDataHere")
+}
+
+func Test_newDecompressor(t *testing.T) {
 	tests := []struct {
-		name     string
-		imageURL string
-		reader   func(*testing.T) io.Reader
-		wantOut  io.Reader
-		wantErr  bool
+		name        string
+		compression Compression
+		reader      func(*testing.T) io.Reader
+		wantErr     bool
 	}{
 		{
-			"tar gzip",
-			"http://192.168.0.1/a.tar.gz",
+			"gzip",
+			CompressionGzip,
 			gzipReader,
-			nil,
 			false,
 		},
 		{
 			"broken gzip",
-			"http://192.168.0.1/a.gz",
+			CompressionGzip,
 			xzReader,
-			nil,
 			true,
 		},
 		{
 			"xz",
-			"http://192.168.0.1/a.xz",
+			CompressionXZ,
 			xzReader,
-			nil,
 			false,
 		},
 		{
-			"unknown",
-			"http://192.168.0.1/a.abc",
-			xzReader,
-			nil,
-			true,
+			"none",
+			CompressionNone,
+			rawReader,
+			false,
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := findDecompressor(tt.imageURL, tt.reader(t))
+			_, err := newDecompressor(tt.compression, tt.reader(t))
 			if (err != nil) != tt.wantErr {
-				t.Errorf("findDecompressor() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("newDecompressor() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+		})
+	}
+}
+
+func TestParseCompression(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		imageURL string
+		expected Compression
+	}{
+		{"gz", "gz", "", CompressionGzip},
+		{"gzip", "gzip", "", CompressionGzip},
+		{"xz", "xz", "", CompressionXZ},
+		{"zstd", "zstd", "", CompressionZstd},
+		{"zst", "zst", "", CompressionZstd},
+		{"bzip2", "bzip2", "", CompressionBzip2},
+		{"empty", "", "", CompressionNone},
+		{"false", "false", "", CompressionNone},
+		{"unknown", "unknown", "", CompressionNone},
+		// Backward compatibility: true with URL detection
+		{"true with .gz URL", "true", "registry/image:tag.gz", CompressionGzip},
+		{"true with .xz URL", "true", "registry/image:tag.xz", CompressionXZ},
+		{"true with .zst URL", "true", "registry/image:tag.zst", CompressionZstd},
+		{"true with .bzip2 URL", "true", "registry/image:tag.bzip2", CompressionBzip2},
+		{"true with no extension", "true", "registry/image:latest", CompressionNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseCompression(tt.input, tt.imageURL)
+			if got != tt.expected {
+				t.Errorf("ParseCompression(%q, %q) = %v, want %v", tt.input, tt.imageURL, got, tt.expected)
 			}
 		})
 	}

--- a/oci2disk/image/image_test.go
+++ b/oci2disk/image/image_test.go
@@ -102,14 +102,18 @@ func TestParseCompression(t *testing.T) {
 		{"xz", "xz", "", CompressionXZ},
 		{"zstd", "zstd", "", CompressionZstd},
 		{"zst", "zst", "", CompressionZstd},
+		{"zs", "zs", "", CompressionZstd},
 		{"bzip2", "bzip2", "", CompressionBzip2},
 		{"empty", "", "", CompressionNone},
 		{"false", "false", "", CompressionNone},
 		{"unknown", "unknown", "", CompressionNone},
 		// Backward compatibility: true with URL detection
 		{"true with .gz URL", "true", "registry/image:tag.gz", CompressionGzip},
+		{"true with .gzip URL", "true", "registry/image:tag.gzip", CompressionGzip},
 		{"true with .xz URL", "true", "registry/image:tag.xz", CompressionXZ},
+		{"true with .zstd URL", "true", "registry/image:tag.zstd", CompressionZstd},
 		{"true with .zst URL", "true", "registry/image:tag.zst", CompressionZstd},
+		{"true with .zs URL", "true", "registry/image:tag.zs", CompressionZstd},
 		{"true with .bzip2 URL", "true", "registry/image:tag.bzip2", CompressionBzip2},
 		{"true with no extension", "true", "registry/image:latest", CompressionNone},
 	}

--- a/oci2disk/image/writer.go
+++ b/oci2disk/image/writer.go
@@ -13,13 +13,12 @@ import (
 
 // DiskImageStore -.
 type DiskImageStore struct {
-	sourceImage string
+	compression Compression
 	writer      io.Writer
-	compressed  bool
 }
 
 // NewDiskImageStore -.
-func NewDiskImageStore(sourceImage string, compressed bool, w io.Writer) DiskImageStore {
+func NewDiskImageStore(compression Compression, w io.Writer) DiskImageStore {
 	// we have to reprocess the opts to find the blocksize
 	// var wOpts := content.DefaultWriterOpts()
 	// for _, opt := range opts {
@@ -28,7 +27,7 @@ func NewDiskImageStore(sourceImage string, compressed bool, w io.Writer) DiskIma
 	// 		continueå
 	// 	}
 	// }
-	return DiskImageStore{sourceImage: sourceImage, writer: w, compressed: compressed}
+	return DiskImageStore{compression: compression, writer: w}
 }
 
 // Writer get a writer.
@@ -124,25 +123,17 @@ func (d DiskImageStore) Writer(_ context.Context, opts ...ctrcontent.WriterOpt) 
 	if desc.Annotations["org.opencontainers.image.title"] == "" {
 		return content.NewIoContentWriter(io.Discard, content.WithOutputHash(desc.Digest)), nil
 	}
-	if !d.compressed {
-		// Without compression send raw output
-		f = func(r io.Reader, w io.Writer, done chan<- error) {
-			var err error
-			b := make([]byte, wOpts.Blocksize)
-			_, err = io.CopyBuffer(w, r, b)
-			done <- err
+
+	compression := d.compression
+	f = func(r io.Reader, w io.Writer, done chan<- error) {
+		decompressReader, err := newDecompressor(compression, r)
+		if err != nil {
+			log.Fatalf(err.Error()) //nolint:revive // this is fine
 		}
-	} else {
-		f = func(r io.Reader, w io.Writer, done chan<- error) {
-			decompressReader, err := findDecompressor(d.sourceImage, r)
-			if err != nil {
-				log.Fatalf(err.Error()) //nolint:revive // this is fine
-			}
-			defer decompressReader.Close()
-			b := make([]byte, wOpts.Blocksize)
-			_, err = io.CopyBuffer(w, decompressReader, b)
-			done <- err
-		}
+		defer decompressReader.Close()
+		b := make([]byte, wOpts.Blocksize)
+		_, err = io.CopyBuffer(w, decompressReader, b)
+		done <- err
 	}
 	writerOpts := []content.WriterOpt{}
 	return content.NewPassthroughWriter(di, f, writerOpts...), nil

--- a/oci2disk/main.go
+++ b/oci2disk/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strconv"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tinkerbell/actions/oci2disk/image"
@@ -15,11 +14,10 @@ func main() {
 	img := os.Getenv("IMG_URL")
 	compressedEnv := os.Getenv("COMPRESSED")
 
-	// We can ignore the error and default compressed to false.
-	cmp, _ := strconv.ParseBool(compressedEnv)
+	compression := image.ParseCompression(compressedEnv, img)
 
 	// Write the image to disk
-	err := image.Write(img, disk, cmp)
+	err := image.Write(img, disk, compression)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
…OMPRESSED environment variable so that the image tag does not need to have the compression extension as a "file extension". still keep the backward compatibility with COMPRESSED=true so that the imageUrl (i.e. the image tag) is parsed for the compression algorithm

## Description

Change affects the action oci2disk:

Currently the compression type needs to be in the image tag as a suffix which is a design flaw in my opinion.
This PR gives the user the ability to pass the compression type of the image by using the existing COMPRESSED env variable.

Backward compatibility is kept with COMPRESSED=true. If true, the code tries to detect the compression type the old way (the suffix of the image url, which is in most cases the "suffix" of the image tag)

Documentation is clearer now as well.

Fixes: #

## How Has This Been Tested?
new unit tests for this small change, so that the given variable is respected correctly
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

Backward compatibility is kept. Users can additionally pass the compression by using the existing COMPRESSED variable.



<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] added unit or e2e tests
- [x] provided instructions on how to upgrade
