### PR TITLE
oci2disk: fail fast if the given destinationDevice (via env DEST_DISK…

### DIFF
--- a/oci2disk/image/image.go
+++ b/oci2disk/image/image.go
@@ -52,6 +52,11 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 
 	resolver := docker.NewResolver(opts)
 
+	// Check that the destination device exists before attempting to open it.
+	if _, err := os.Stat(destinationDevice); err != nil {
+		return fmt.Errorf("destination device %s does not exist", destinationDevice)
+	}
+
 	fileOut, err := os.OpenFile(destinationDevice, os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err


### PR DESCRIPTION
…) does not exist. otherwise the action waits for a very long time.

maybe the os.O_CREATE is not necessary as would fix this, too, see image2disk action. However, checking before opening is a sure fix.

## Description

Change affects the action oci2disk:

When a DISK_DEST is given which does not exist on the machine, the action tries to open the file and waits for a very long time (maybe indefinitely?).

The change just checks the availability of the given device before opening it.

I noted that the action image2disk just uses the flag os.O_WRONLY in openfile vs. the oci2disk action uses os.O_WRONLY|os.O_CREATE.

However, I just added the check beforehand so that it is safe to use. Maybe there is a reason for the os.O_CREATE flag here.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

A wrongly given DISK_DEST fails fast, instead of a hanging oci2disk action.

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
