### PR TITLE
feat: registry auth for oci2disk

### DIFF
--- a/oci2disk/README.md
+++ b/oci2disk/README.md
@@ -29,6 +29,9 @@ actions:
       DEST_DISK: /dev/nvme0n1
       IMG_URL: "192.168.0.173/test/debian:raw.gz"
       COMPRESSED: true
+      # optional fields for registry authentication
+      REGISTRY_USERNAME: "foo"
+      REGISTRY_PASSWORD: "bar
 ```
 
 ## Compression format supported:

--- a/oci2disk/image/image.go
+++ b/oci2disk/image/image.go
@@ -38,7 +38,7 @@ func (wc *WriteCounter) Write(p []byte) (int, error) {
 // Write will pull an image and write it to local storage device
 // with compress set to true it will use gzip compression to expand the data before
 // writing to an underlying device.
-func Write(sourceImage, destinationDevice string, compressed bool) error {
+func Write(sourceImage, destinationDevice string, compressed bool, registryUsername, registryPassword string) error {
 	ctx := context.Background()
 	client := http.DefaultClient
 	opts := docker.ResolverOptions{}
@@ -49,6 +49,13 @@ func Write(sourceImage, destinationDevice string, compressed bool) error {
 	}
 
 	opts.Client = client
+
+	if registryUsername != "" && registryPassword != "" {
+		log.Infof("Registry credentials provided, using authenticated pull")
+		opts.Credentials = func(hostName string) (string, string, error) {
+			return registryUsername, registryPassword, nil
+		}
+	}
 
 	resolver := docker.NewResolver(opts)
 

--- a/oci2disk/main.go
+++ b/oci2disk/main.go
@@ -14,12 +14,14 @@ func main() {
 	disk := os.Getenv("DEST_DISK")
 	img := os.Getenv("IMG_URL")
 	compressedEnv := os.Getenv("COMPRESSED")
+	registryUsername := os.Getenv("REGISTRY_USERNAME")
+	registryPassword := os.Getenv("REGISTRY_PASSWORD")
 
 	// We can ignore the error and default compressed to false.
 	cmp, _ := strconv.ParseBool(compressedEnv)
 
 	// Write the image to disk
-	err := image.Write(img, disk, cmp)
+	err := image.Write(img, disk, cmp, registryUsername, registryPassword)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Add registry authentication support to `oci2disk`. We have a use-case where our registry does not support anonymous access, so provisioning nodes with OCI images stored there requires passing registry credentials.

Two new env vars are introduced for authentication:
- `REGISTRY_USERNAME`
- `REGISTRY_PASSWORD` 

Fixes: #171

## How Has This Been Tested?

Here are the test cases to prove the PR works:
 
 **Setup**
 
 Create two registries, one authenticated and the other without authentication. Build the binary and put it in the test directory.
 
 ```bash
mkdir -p /tmp/oci2disk-test/auth

# Build 
go build -o /tmp/oci2disk-test/oci2disk ./oci2disk/

# Create a test artifact
echo "test-data" | gzip > /tmp/oci2disk-test/testfile.raw.gz

# Create a htpasswd file with a test user
docker run --rm --entrypoint htpasswd httpd:2 \
  -Bbn testuser testpassword > /tmp/oci2disk-test/auth/htpasswd

# Run authenticated registry
docker run -d -p 5000:5000 --name authreg \
  -v /tmp/oci2disk-test/auth:/auth \
  -e REGISTRY_AUTH=htpasswd \
  -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" \
  -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd \
  registry:2

# Run a non-authenticated registry
docker run -d -p 5001:5000 --name openreg registry:2
```

Push the test artifact into both registries for testing

```bash
cd /tmp/oci2disk-test

# auth registry
oras push --plain-http \
  -u testuser -p testpassword \
  localhost:5000/test/image:latest \
  testfile.raw.gz:application/vnd.oci.image.layer.v1.tar

# no auth
oras push --plain-http \
  localhost:5001/test/image:latest \
  testfile.raw.gz:application/vnd.oci.image.layer.v1.tar
```

Test oci2disk on auth registry with no creds - expect a fail

```bash
DEST_DISK=/tmp/oci2disk-test/output.raw \
IMG_URL=localhost:5000/test/image:latest \
COMPRESSED=false \
/tmp/oci2disk-test/oci2disk
```

Expectation
```bash
FATA[0000] unexpected status code [manifests latest]: 401 Unauthorized
```

Test oci2disk on auth registry with creds - should work

```bash
DEST_DISK=/tmp/oci2disk-test/output.raw \
IMG_URL=localhost:5000/test/image:latest \
COMPRESSED=false \
REGISTRY_USERNAME=testuser \
REGISTRY_PASSWORD=testpassword \
/tmp/oci2disk-test/oci2disk
```

Expectation 

```bash
INFO[0000] Successfully written [localhost:5000/test/image:latest] to [/tmp/oci2disk-test/output.raw]
```

Make sure changes do not affect previous flow by pushing to no-auth registry with no creds

```bash
DEST_DISK=/tmp/oci2disk-test/output.raw \
IMG_URL=localhost:5001/test/image:latest \
COMPRESSED=false \
/tmp/oci2disk-test/oci2disk
```

Expectation

```bash
INFO[0000] Successfully written [localhost:5001/test/image:latest] to [/tmp/oci2disk-test/output.raw] 
```


<!--- Include details of your testing environment, and the tests you ran to -->
Ubuntu with oras and docker.

<!--- see how your change affects other areas of the code, etc. -->
There are no affects to other areas of code.


## How are existing users impacted? What migration steps/scripts do we need?

No impact.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required) 
- [x] added unit or e2e tests (N/A)
- [x] provided instructions on how to upgrade (N/A)
