### PR TITLE
archive2disk: verify TARFILE_CHECKSUM against the downloaded archive

### DIFF
--- a/archive2disk/README.md
+++ b/archive2disk/README.md
@@ -19,8 +19,11 @@ Archive types supported:
 Environment Variables:
   - ARCHIVE_URL (Required) Specify the compressed file URL
   - ARCHIVE_TYPE (Required) Specify the type of archive.  Supported archive types are TAR and TARGZ
-  - TARFILE_CHECKSUM (Required, overridable) Specify the checksum of the TAR file
-    The format for specifying the checksum is algorithm:hash. See examples below, more informaiton can be found at github.com/opencontainers/go-digest
+  - TARFILE_CHECKSUM (Required, overridable) Specify the checksum of the downloaded archive.
+    The format is `algorithm:hash` (e.g. `sha256:...`). The hash is verified against the raw
+    bytes of the archive as downloaded over HTTP, so it matches the output of running
+    `sha256sum file.tar.gz` (or `sha512sum`) on the archive locally. See examples below; more
+    information can be found at github.com/opencontainers/go-digest
   - INSECURE_NO_TARFILE_CHECKSUM_VERIFICATION (optional) Set to true to skip the check for the TARFILE_CHECKSUM environment variable
   - DEST_DISK (Required) Specify the block device that will get mounted and where the archive will uncompress
   - FS_TYPE (Required) Specify the file system type of DEST_DISK

--- a/archive2disk/archive/archive.go
+++ b/archive2disk/archive/archive.go
@@ -4,15 +4,24 @@ package archive
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
 
+	// See https://github.com/opencontainers/go-digest#usage
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 // Write will pull an image and write it to local storage device image must be a tar file or tar.gz file as set by archiveType.
+// When checksum is non-empty it must be of the form "<algorithm>:<hash>" (e.g. sha256:...) and is verified against
+// the raw HTTP response body (i.e. the bytes of the downloaded archive as produced by `sha256sum file.tar.gz`).
 func Write(archiveURL, archiveType, path string, checksum string, httpTimeoutVal int) error {
 	req, err := http.NewRequest("GET", archiveURL, nil)
 	if err != nil {
@@ -41,19 +50,44 @@ func Write(archiveURL, archiveType, path string, checksum string, httpTimeoutVal
 		return fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
+	// Wrap the raw HTTP body with a TeeReader so the verifier hashes the full
+	// downloaded archive (what users get from `sha256sum file.tar.gz`), not just
+	// the bytes consumed by tar/gzip parsers.
+	var verifier digest.Verifier
+	var reader io.Reader = resp.Body
+	if checksum != "" {
+		log.Infof("checksum validation enabled [%s]", checksum)
+		dd, err := digest.Parse(checksum)
+		if err != nil {
+			return fmt.Errorf("failed to parse digest - %w", err)
+		}
+		verifier = dd.Verifier()
+		reader = io.TeeReader(resp.Body, verifier)
+	}
+
 	switch strings.ToLower(archiveType) {
 	case "tar":
-		err := extractTarDirectory(absPath, checksum, resp.Body)
-		if err != nil {
+		if err := extractTarDirectory(absPath, reader); err != nil {
 			return fmt.Errorf("[ERROR] New gzip reader: %w", err)
 		}
 	case "targz":
-		err := extractTarGzip(absPath, checksum, resp.Body)
-		if err != nil {
+		if err := extractTarGzip(absPath, reader); err != nil {
 			return fmt.Errorf("[ERROR] New gzip reader: %w", err)
 		}
 	default:
 		return fmt.Errorf("[ERROR] Unknown archiveType supplied: %v", archiveType)
 	}
+
+	if verifier != nil {
+		// Drain any remaining bytes (gzip footer, tar padding past end-of-archive
+		// marker, etc.) so the verifier sees the entire HTTP body.
+		if _, err := io.Copy(io.Discard, reader); err != nil {
+			return fmt.Errorf("failed to drain response body for checksum verification: %w", err)
+		}
+		if !verifier.Verified() {
+			return errors.New("digest mismatch")
+		}
+	}
+
 	return nil
 }

--- a/archive2disk/archive/archive_test.go
+++ b/archive2disk/archive/archive_test.go
@@ -1,0 +1,153 @@
+package archive
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildTarGz builds a small in-memory gzipped tar archive containing a single
+// regular file and returns the compressed bytes.
+func buildTarGz(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	content := []byte("hello archive2disk\n")
+	hdr := &tar.Header{
+		Name:     "hello.txt",
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("write tar header: %v", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		t.Fatalf("write tar content: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar writer: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip writer: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+// newArchiveServer returns an httptest server that serves the given bytes at /archive.tar.gz.
+func newArchiveServer(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestWrite_CorrectChecksum_Succeeds(t *testing.T) {
+	archiveBytes := buildTarGz(t)
+	srv := newArchiveServer(t, archiveBytes)
+	defer srv.Close()
+
+	dest := t.TempDir()
+	checksum := "sha256:" + sha256Hex(archiveBytes)
+
+	if err := Write(srv.URL+"/archive.tar.gz", "targz", dest, checksum, 1); err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "hello.txt"))
+	if err != nil {
+		t.Fatalf("expected extracted file to exist: %v", err)
+	}
+	if string(got) != "hello archive2disk\n" {
+		t.Fatalf("unexpected extracted content: %q", string(got))
+	}
+}
+
+func TestWrite_WrongChecksum_ReturnsDigestMismatch(t *testing.T) {
+	archiveBytes := buildTarGz(t)
+	srv := newArchiveServer(t, archiveBytes)
+	defer srv.Close()
+
+	dest := t.TempDir()
+	// A syntactically valid but incorrect sha256.
+	wrong := "sha256:" + strings.Repeat("0", 64)
+
+	err := Write(srv.URL+"/archive.tar.gz", "targz", dest, wrong, 1)
+	if err == nil {
+		t.Fatalf("expected digest mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("expected error containing 'digest mismatch', got: %v", err)
+	}
+}
+
+func TestWrite_EmptyChecksum_SkipsVerification(t *testing.T) {
+	archiveBytes := buildTarGz(t)
+	srv := newArchiveServer(t, archiveBytes)
+	defer srv.Close()
+
+	dest := t.TempDir()
+
+	if err := Write(srv.URL+"/archive.tar.gz", "targz", dest, "", 1); err != nil {
+		t.Fatalf("expected success with no checksum, got error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, "hello.txt")); err != nil {
+		t.Fatalf("expected extracted file to exist: %v", err)
+	}
+}
+
+func TestWrite_MalformedChecksum_ReturnsParseError(t *testing.T) {
+	archiveBytes := buildTarGz(t)
+	srv := newArchiveServer(t, archiveBytes)
+	defer srv.Close()
+
+	dest := t.TempDir()
+
+	err := Write(srv.URL+"/archive.tar.gz", "targz", dest, "not-a-valid-digest", 1)
+	if err == nil {
+		t.Fatalf("expected parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse digest") {
+		t.Fatalf("expected error containing 'failed to parse digest', got: %v", err)
+	}
+}
+
+// TestWrite_ChecksumMatchesSha256OfHTTPBody is a belt-and-braces check that the
+// checksum users are expected to pass is literally `sha256sum file.tar.gz` of
+// the bytes on the wire, not the hash of decompressed or tar-framed content.
+func TestWrite_ChecksumMatchesSha256OfHTTPBody(t *testing.T) {
+	archiveBytes := buildTarGz(t)
+
+	// Compute what a user would get from `sha256sum` on the compressed file.
+	sum := sha256.Sum256(archiveBytes)
+	expected := fmt.Sprintf("sha256:%x", sum)
+
+	srv := newArchiveServer(t, archiveBytes)
+	defer srv.Close()
+
+	dest := t.TempDir()
+	if err := Write(srv.URL+"/archive.tar.gz", "targz", dest, expected, 1); err != nil {
+		t.Fatalf("expected the sha256 of the raw HTTP body to verify, got error: %v", err)
+	}
+}

--- a/archive2disk/archive/utils.go
+++ b/archive2disk/archive/utils.go
@@ -7,27 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
-	// See https://github.com/opencontainers/go-digest#usage
-	_ "crypto/sha256"
-	_ "crypto/sha512"
-	"fmt"
-
-	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func extractTarDirectory(root string, checksum string, r io.Reader) error {
-	var verifier digest.Verifier
-	if checksum != "" {
-		log.Infof("checksum validation during untar [%s]", checksum)
-		dd, err := digest.Parse(checksum)
-		if err != nil {
-			return fmt.Errorf("failed to parse digest - %w", err)
-		}
-		verifier = dd.Verifier()
-		r = io.TeeReader(r, verifier)
-	}
+func extractTarDirectory(root string, r io.Reader) error {
 	hardLinks := make(map[string]string)
 	tr := tar.NewReader(r)
 	for {
@@ -92,19 +75,14 @@ func extractTarDirectory(root string, checksum string, r io.Reader) error {
 		}
 	}
 
-	if verifier != nil && !verifier.Verified() {
-		return errors.New("digest mismatch")
-	}
-
 	return nil
 }
 
-func extractTarGzip(root string, checksum string, g io.Reader) error {
+func extractTarGzip(root string, g io.Reader) error {
 	zr, err := gzip.NewReader(g)
 	if err != nil {
 		return err
 	}
 	defer zr.Close()
-	var r io.Reader = zr
-	return extractTarDirectory(root, checksum, r)
+	return extractTarDirectory(root, zr)
 }


### PR DESCRIPTION
## Summary

Fix `TARFILE_CHECKSUM` so it matches the obvious expectation — sha256 of the archive as downloaded.

## The bug

The checksum verifier wrapped an `io.TeeReader` around the reader *after* `gzip.NewReader` + `tar.NewReader`, so it only ever hashed the bytes Go's `tar.Reader` actually consumed. Since `tar.Reader` stops at the end-of-archive zero blocks, the verifier missed:

- the gzip CRC+size footer,
- any tar padding past the end-of-archive marker (GNU tar blocking factor defaults to 20 → always some),
- for plain-tar archives, any trailing bytes past end-of-archive.

Neither `sha256sum file.tar.gz` nor `gunzip -c file.tar.gz | sha256sum` matches that — and there's no precomputable value a user could pass that would match short of re-implementing the action's tar reader. In practice any `TARFILE_CHECKSUM` fails with `digest mismatch` at the end of a successful extraction.

## The fix

Move the verifier into `archive.Write()` so it tees the raw HTTP body **before** any decompression. After extraction, drain any remaining bytes so the verifier sees the complete stream, then call `Verified()`. `TARFILE_CHECKSUM` now matches `sha256sum file.tar.gz`.

`extractTarDirectory` and `extractTarGzip` no longer take a `checksum` parameter — they just extract. `INSECURE_NO_TARFILE_CHECKSUM_VERIFICATION` behaviour unchanged (`main.go` passes an empty string).

## Tests

New `archive2disk/archive/archive_test.go` (stdlib only, no new module deps). Uses `httptest.NewServer` to serve an in-memory tar.gz. Covers:

- Correct sha256 → success.
- Wrong sha256 → returns `digest mismatch`.
- Empty checksum (verification skipped) → success.
- Malformed checksum → parse error.
- Explicit assertion that the value users pass is literally `sha256sum` of the HTTP body.

All five pass in `golang:1.21-alpine` via docker.

## Docs

`README.md` clarifies that `TARFILE_CHECKSUM` matches `sha256sum file.tar.gz`.

## Test plan

- [x] `go test ./archive2disk/...` passes.
- [x] Verified end-to-end on bare-metal provisioning against a known-good tarball: pin `sha256:$(sha256sum tarball.tar.gz | cut -d' ' -f1)` in `TARFILE_CHECKSUM`, action succeeds. Mangle a byte of the served tarball, action fails with `digest mismatch`.