### PR TITLE
restore anonymous registry pulls:

### DIFF
--- a/oci2disk/image/image.go
+++ b/oci2disk/image/image.go
@@ -49,16 +49,20 @@ func Write(sourceImage, destinationDevice string, compressed bool, registryUsern
 		},
 	}
 
-	registryOpts := []docker.RegistryOpt{docker.WithClient(client)}
+	// Always install an authorizer so the resolver can handle Bearer-token
+	// challenges from registries like ghcr.io even for anonymous pulls. When
+	// credentials are provided, wire them into the auth callback; otherwise the
+	// authorizer performs an unauthenticated token exchange.
+	authorizerOpts := []docker.AuthorizerOpt{docker.WithAuthClient(client)}
 	if registryUsername != "" && registryPassword != "" {
 		log.Infof("Registry credentials provided, using authenticated pull")
-		authorizer := docker.NewDockerAuthorizer(
-			docker.WithAuthClient(client),
-			docker.WithAuthCreds(func(_ string) (string, string, error) {
-				return registryUsername, registryPassword, nil
-			}),
-		)
-		registryOpts = append(registryOpts, docker.WithAuthorizer(authorizer))
+		authorizerOpts = append(authorizerOpts, docker.WithAuthCreds(func(_ string) (string, string, error) {
+			return registryUsername, registryPassword, nil
+		}))
+	}
+	registryOpts := []docker.RegistryOpt{
+		docker.WithClient(client),
+		docker.WithAuthorizer(docker.NewDockerAuthorizer(authorizerOpts...)),
 	}
 
 	resolver := docker.NewResolver(docker.ResolverOptions{


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The resolver setup only installed an Authorizer when registry credentials were supplied. Without an authorizer the docker resolver has no way to answer a Bearer-token challenge, so anonymous pulls from registries that always challenge (e.g. ghcr.io, even for public images) fail with 401 on the first HEAD request. The previous code worked because docker.NewResolver synthesized a default authorizer with nil creds, which still performs the unauthenticated token exchange.

Always install a docker authorizer and only attach the credential callback when both username and password are set.

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
